### PR TITLE
Fix implementation spec metadata

### DIFF
--- a/Docs/10_CoreDocs/15_ImplementationSpecs/00_index.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/00_index.md
@@ -2,11 +2,14 @@
 title: 実装仕様
 version: 0.4.0
 status: approved
-updated: 2025-06-07
+updated: 2025-06-06
 tags:
     - Implementation
     - Specification
     - Core
+linked_docs:
+    - "[[14_TechDocs/00_index.md]]"
+    - "[[DocumentManagementRules.md]]"
 ---
 
 # 実装仕様

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.10_PermanentUpgradeSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.10_PermanentUpgradeSpec.md
@@ -1,12 +1,14 @@
 ---
 title: 永続アップグレードシステム実装仕様
-version: 0.1.0
-status: draft
-updated: 2024-03-19
+version: 0.2.0
+status: approved
+updated: 2025-06-06
 tags:
     - Implementation
     - Progression
     - Gameplay
+linked_docs:
+    - "[[14.13_TechnicalDesignSpec.md]]"
 ---
 
 # 永続アップグレードシステム実装仕様

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.11_TutorialRoomSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.11_TutorialRoomSpec.md
@@ -1,12 +1,14 @@
 ---
 title: チュートリアル部屋実装仕様
-version: 0.1.0
-status: draft
-updated: 2024-03-19
+version: 0.2.0
+status: approved
+updated: 2025-06-06
 tags:
     - Implementation
     - Tutorial
     - Gameplay
+linked_docs:
+    - "[[14.13_TechnicalDesignSpec.md]]"
 ---
 
 # チュートリアル部屋実装仕様

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.12_PerformanceOptimizationSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.12_PerformanceOptimizationSpec.md
@@ -1,31 +1,30 @@
 ---
-title: Performance Optimization Implementation Specification
+title: パフォーマンス最適化実装仕様
 version: 0.3
 status: approved
-updated: 2025-06-07
+updated: 2025-06-06
 tags:
     - Implementation
     - Performance
     - Optimization
-related_tech_docs:
-    - 14.1_Requirement.md
-    - 14.2_PrototypeTechnicalDesign.md
-    - 14.3_GodotEnvironment.md
-    - 14.4_ReactiveSystem.md
-    - 14.5_StateManagement.md
-    - 14.11_TestAutomation.md
-    - 14.12_PerformanceProfiling.md
-    - 14.13_TechnicalDesignSpec.md
-    - 14.18_SystemArchitecture.md
-related_impl_specs:
-    - 15.1_ReactiveSystemImpl.md
-    - 15.2_StateManagementImpl.md
-    - 15.3_EnemyAISpec.md
-    - 15.4_CombatSystemSpec.md
-    - 15.5_SkillSystemSpec.md
-    - 15.6_SaveLoadSpec.md
-    - 15.7_UIUXSpec.md
-    - 15.8_TestPerformanceSpec.md
+linked_docs:
+    - "[[14.1_Requirement.md]]"
+    - "[[14.2_PrototypeTechnicalDesign.md]]"
+    - "[[14.3_GodotEnvironment.md]]"
+    - "[[14.4_ReactiveSystem.md]]"
+    - "[[14.5_StateManagement.md]]"
+    - "[[14.11_TestAutomation.md]]"
+    - "[[14.12_PerformanceProfiling.md]]"
+    - "[[14.13_TechnicalDesignSpec.md]]"
+    - "[[14.18_SystemArchitecture.md]]"
+    - "[[15.1_ReactiveSystemImpl.md]]"
+    - "[[15.2_StateManagementImpl.md]]"
+    - "[[15.3_EnemyAISpec.md]]"
+    - "[[15.4_CombatSystemSpec.md]]"
+    - "[[15.5_SkillSystemSpec.md]]"
+    - "[[15.6_SaveLoadSpec.md]]"
+    - "[[15.7_UIUXSpec.md]]"
+    - "[[15.8_TestPerformanceSpec.md]]"
 ---
 
 # パフォーマンス最適化実装仕様

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.13_AchievementSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.13_AchievementSpec.md
@@ -2,11 +2,13 @@
 title: 実績システム実装仕様
 version: 0.3
 status: approved
-updated: 2025-06-07
+updated: 2025-06-06
 tags:
     - Implementation
     - Achievement
     - Gameplay
+linked_docs:
+    - "[[14.13_TechnicalDesignSpec.md]]"
 ---
 
 # 実績システム実装仕様

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.14_LocalizationSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.14_LocalizationSpec.md
@@ -2,11 +2,13 @@
 title: 多言語対応実装仕様
 version: 0.3
 status: approved
-updated: 2025-06-07
+updated: 2025-06-06
 tags:
     - Implementation
     - Localization
     - UI
+linked_docs:
+    - "[[14.13_TechnicalDesignSpec.md]]"
 ---
 
 # 多言語対応実装仕様

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.15_TestErrorGuidelines.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.15_TestErrorGuidelines.md
@@ -1,17 +1,16 @@
 ---
 title: テスト計画とエラー処理ガイドライン
-version: 0.1
-status: draft
-updated: 2024-03-19
+version: 0.2
+status: approved
+updated: 2025-06-06
 tags:
     - Implementation
     - Test
     - Error Handling
-related_tech_docs:
-    - 14.11_TestAutomation.md
-    - 14.12_PerformanceProfiling.md
-related_impl_specs:
-    - 15.8_TestPerformanceSpec.md
+linked_docs:
+    - "[[14.11_TestAutomation.md]]"
+    - "[[14.12_PerformanceProfiling.md]]"
+    - "[[15.8_TestPerformanceSpec.md]]"
 ---
 
 # テスト計画とエラー処理ガイドライン

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.1_InputManagementSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.1_InputManagementSpec.md
@@ -1,19 +1,18 @@
 ---
-title: Input Management Specification
-version: 0.2
-status: draft
-updated: 2025-05-29
+title: 入力管理実装仕様
+version: 0.3
+status: approved
+updated: 2025-06-06
 tags:
     - Implementation
     - Input
-related_tech_docs:
-    - 14.1_Requirement.md
-    - 14.2_PrototypeTechnicalDesign.md
-    - 14.4_InputStateMachine.md
-    - 14.13_TechnicalDesignSpec.md
-related_impl_specs:
-    - 15.7_UIUXSpec.md
-    - 15.9_AccessibilitySpec.md
+linked_docs:
+    - "[[14.1_Requirement.md]]"
+    - "[[14.2_PrototypeTechnicalDesign.md]]"
+    - "[[14.4_InputStateMachine.md]]"
+    - "[[14.13_TechnicalDesignSpec.md]]"
+    - "[[15.7_UIUXSpec.md]]"
+    - "[[15.9_AccessibilitySpec.md]]"
 ---
 
 # 入力管理実装仕様

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.1_ReactiveSystemImpl.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.1_ReactiveSystemImpl.md
@@ -1,28 +1,27 @@
 ---
-title: Reactive System Implementation Specification
+title: リアクティブシステム実装仕様
 version: 0.3
 status: approved
-updated: 2025-06-07
+updated: 2025-06-06
 tags:
     - Implementation
     - Reactive
-related_tech_docs:
-    - 14.1_Requirement.md
-    - 14.2_PrototypeTechnicalDesign.md
-    - 14.3_GodotEnvironment.md
-    - 14.4_ReactiveSystem.md
-    - 14.5_StateManagement.md
-    - 14.13_TechnicalDesignSpec.md
-    - 14.18_SystemArchitecture.md
-related_impl_specs:
-    - 15.2_StateManagementImpl.md
-    - 15.3_EnemyAISpec.md
-    - 15.4_CombatSystemSpec.md
-    - 15.5_SkillSystemSpec.md
-    - 15.6_SaveLoadSpec.md
-    - 15.7_UIUXSpec.md
-    - 15.8_TestPerformanceSpec.md
-    - 15.12_PerformanceOptimizationSpec.md
+linked_docs:
+    - "[[14.1_Requirement.md]]"
+    - "[[14.2_PrototypeTechnicalDesign.md]]"
+    - "[[14.3_GodotEnvironment.md]]"
+    - "[[14.4_ReactiveSystem.md]]"
+    - "[[14.5_StateManagement.md]]"
+    - "[[14.13_TechnicalDesignSpec.md]]"
+    - "[[14.18_SystemArchitecture.md]]"
+    - "[[15.2_StateManagementImpl.md]]"
+    - "[[15.3_EnemyAISpec.md]]"
+    - "[[15.4_CombatSystemSpec.md]]"
+    - "[[15.5_SkillSystemSpec.md]]"
+    - "[[15.6_SaveLoadSpec.md]]"
+    - "[[15.7_UIUXSpec.md]]"
+    - "[[15.8_TestPerformanceSpec.md]]"
+    - "[[15.12_PerformanceOptimizationSpec.md]]"
 ---
 
 # リアクティブシステム実装仕様書

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.2_DungeonGenerationSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.2_DungeonGenerationSpec.md
@@ -1,20 +1,19 @@
 ---
-title: Dungeon Generation Specification
-version: 0.2
-status: draft
-updated: 2025-05-29
+title: ダンジョン生成実装仕様
+version: 0.3
+status: approved
+updated: 2025-06-06
 tags:
     - Implementation
     - Dungeon
-related_tech_docs:
-    - 14.1_Requirement.md
-    - 14.2_PrototypeTechnicalDesign.md
-    - 14.5_DungeonGeneration.md
-    - 14.13_TechnicalDesignSpec.md
-related_impl_specs:
-    - 15.3_EnemyAISpec.md
-    - 15.4_CombatSystemSpec.md
-    - 15.11_TutorialRoomSpec.md
+linked_docs:
+    - "[[14.1_Requirement.md]]"
+    - "[[14.2_PrototypeTechnicalDesign.md]]"
+    - "[[14.5_DungeonGeneration.md]]"
+    - "[[14.13_TechnicalDesignSpec.md]]"
+    - "[[15.3_EnemyAISpec.md]]"
+    - "[[15.4_CombatSystemSpec.md]]"
+    - "[[15.11_TutorialRoomSpec.md]]"
 ---
 
 # ダンジョン生成実装仕様

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.2_StateManagementImpl.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.2_StateManagementImpl.md
@@ -1,25 +1,24 @@
 ---
-title: State Management Implementation Specification
+title: 状態管理実装仕様
 version: 0.3
 status: approved
-updated: 2025-06-07
+updated: 2025-06-06
 tags:
     - Implementation
     - State
-related_tech_docs:
-    - 14.1_Requirement.md
-    - 14.2_PrototypeTechnicalDesign.md
-    - 14.3_GodotEnvironment.md
-    - 14.4_ReactiveSystem.md
-    - 14.5_StateManagement.md
-    - 14.13_TechnicalDesignSpec.md
-    - 14.18_SystemArchitecture.md
-related_impl_specs:
-    - 15.1_ReactiveSystemImpl.md
-    - 15.3_EnemyAISpec.md
-    - 15.4_CombatSystemSpec.md
-    - 15.5_SkillSystemSpec.md
-    - 15.6_SaveLoadSpec.md
+linked_docs:
+    - "[[14.1_Requirement.md]]"
+    - "[[14.2_PrototypeTechnicalDesign.md]]"
+    - "[[14.3_GodotEnvironment.md]]"
+    - "[[14.4_ReactiveSystem.md]]"
+    - "[[14.5_StateManagement.md]]"
+    - "[[14.13_TechnicalDesignSpec.md]]"
+    - "[[14.18_SystemArchitecture.md]]"
+    - "[[15.1_ReactiveSystemImpl.md]]"
+    - "[[15.3_EnemyAISpec.md]]"
+    - "[[15.4_CombatSystemSpec.md]]"
+    - "[[15.5_SkillSystemSpec.md]]"
+    - "[[15.6_SaveLoadSpec.md]]"
 ---
 
 # 状態管理実装仕様書

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.3_EnemyAISpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.3_EnemyAISpec.md
@@ -1,22 +1,21 @@
 ---
-title: Enemy AI Specification
+title: 敵AI実装仕様
 version: 0.3
 status: approved
-updated: 2025-06-07
+updated: 2025-06-06
 tags:
     - Implementation
     - AI
-related_tech_docs:
-    - 14.1_Requirement.md
-    - 14.2_PrototypeTechnicalDesign.md
-    - 14.5_DungeonGeneration.md
-    - 14.6_EnemyAIFoundation.md
-    - 14.7_CombatSystem.md
-    - 14.13_TechnicalDesignSpec.md
-related_impl_specs:
-    - 15.2_DungeonGenerationSpec.md
-    - 15.4_CombatSystemSpec.md
-    - 15.11_TutorialRoomSpec.md
+linked_docs:
+    - "[[14.1_Requirement.md]]"
+    - "[[14.2_PrototypeTechnicalDesign.md]]"
+    - "[[14.5_DungeonGeneration.md]]"
+    - "[[14.6_EnemyAIFoundation.md]]"
+    - "[[14.7_CombatSystem.md]]"
+    - "[[14.13_TechnicalDesignSpec.md]]"
+    - "[[15.2_DungeonGenerationSpec.md]]"
+    - "[[15.4_CombatSystemSpec.md]]"
+    - "[[15.11_TutorialRoomSpec.md]]"
 ---
 
 # 敵AI実装仕様

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.5_SkillBuildSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.5_SkillBuildSpec.md
@@ -1,7 +1,7 @@
 ---
 title: スキル・ビルド実装仕様
-version: 0.1.0
-status: draft
+version: 0.2.0
+status: approved
 updated: 2025-06-06
 tags:
     - Implementation

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.5_SkillSystemSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.5_SkillSystemSpec.md
@@ -1,26 +1,25 @@
 ---
-title: Skill System Implementation Specification
+title: スキルシステム実装仕様
 version: 0.3
 status: approved
-updated: 2025-06-07
+updated: 2025-06-06
 tags:
     - Implementation
     - Skill
-related_tech_docs:
-    - 14.1_Requirement.md
-    - 14.2_PrototypeTechnicalDesign.md
-    - 14.3_GodotEnvironment.md
-    - 14.4_ReactiveSystem.md
-    - 14.5_StateManagement.md
-    - 14.7_CombatSystem.md
-    - 14.8_SkillCooldown.md
-    - 14.13_TechnicalDesignSpec.md
-    - 14.18_SystemArchitecture.md
-related_impl_specs:
-    - 15.1_ReactiveSystemImpl.md
-    - 15.2_StateManagementImpl.md
-    - 15.3_EnemyAISpec.md
-    - 15.4_CombatSystemSpec.md
+linked_docs:
+    - "[[14.1_Requirement.md]]"
+    - "[[14.2_PrototypeTechnicalDesign.md]]"
+    - "[[14.3_GodotEnvironment.md]]"
+    - "[[14.4_ReactiveSystem.md]]"
+    - "[[14.5_StateManagement.md]]"
+    - "[[14.7_CombatSystem.md]]"
+    - "[[14.8_SkillCooldown.md]]"
+    - "[[14.13_TechnicalDesignSpec.md]]"
+    - "[[14.18_SystemArchitecture.md]]"
+    - "[[15.1_ReactiveSystemImpl.md]]"
+    - "[[15.2_StateManagementImpl.md]]"
+    - "[[15.3_EnemyAISpec.md]]"
+    - "[[15.4_CombatSystemSpec.md]]"
 ---
 
 # 関連ドキュメント

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.6_SaveLoadSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.6_SaveLoadSpec.md
@@ -1,27 +1,26 @@
 ---
-title: Save/Load System Implementation Specification
+title: セーブ・ロード実装仕様
 version: 0.3
 status: approved
-updated: 2025-06-07
+updated: 2025-06-06
 tags:
     - Implementation
     - Save
     - Load
-related_tech_docs:
-    - 14.1_Requirement.md
-    - 14.2_PrototypeTechnicalDesign.md
-    - 14.3_GodotEnvironment.md
-    - 14.4_ReactiveSystem.md
-    - 14.5_StateManagement.md
-    - 14.9_SaveDataManagement.md
-    - 14.13_TechnicalDesignSpec.md
-    - 14.18_SystemArchitecture.md
-related_impl_specs:
-    - 15.1_ReactiveSystemImpl.md
-    - 15.2_StateManagementImpl.md
-    - 15.3_EnemyAISpec.md
-    - 15.4_CombatSystemSpec.md
-    - 15.5_SkillSystemSpec.md
+linked_docs:
+    - "[[14.1_Requirement.md]]"
+    - "[[14.2_PrototypeTechnicalDesign.md]]"
+    - "[[14.3_GodotEnvironment.md]]"
+    - "[[14.4_ReactiveSystem.md]]"
+    - "[[14.5_StateManagement.md]]"
+    - "[[14.9_SaveDataManagement.md]]"
+    - "[[14.13_TechnicalDesignSpec.md]]"
+    - "[[14.18_SystemArchitecture.md]]"
+    - "[[15.1_ReactiveSystemImpl.md]]"
+    - "[[15.2_StateManagementImpl.md]]"
+    - "[[15.3_EnemyAISpec.md]]"
+    - "[[15.4_CombatSystemSpec.md]]"
+    - "[[15.5_SkillSystemSpec.md]]"
 ---
 
 # セーブ・ロード実装仕様

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.7_UIUXSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.7_UIUXSpec.md
@@ -1,28 +1,27 @@
 ---
-title: UI/UX Implementation Specification
+title: UI/UX実装仕様
 version: 0.3
 status: approved
-updated: 2025-06-07
+updated: 2025-06-06
 tags:
     - Implementation
     - UI
     - UX
-related_tech_docs:
-    - 14.1_Requirement.md
-    - 14.2_PrototypeTechnicalDesign.md
-    - 14.3_GodotEnvironment.md
-    - 14.4_ReactiveSystem.md
-    - 14.5_StateManagement.md
-    - 14.10_UILayout.md
-    - 14.13_TechnicalDesignSpec.md
-    - 14.18_SystemArchitecture.md
-related_impl_specs:
-    - 15.1_ReactiveSystemImpl.md
-    - 15.2_StateManagementImpl.md
-    - 15.3_EnemyAISpec.md
-    - 15.4_CombatSystemSpec.md
-    - 15.5_SkillSystemSpec.md
-    - 15.6_SaveLoadSpec.md
+linked_docs:
+    - "[[14.1_Requirement.md]]"
+    - "[[14.2_PrototypeTechnicalDesign.md]]"
+    - "[[14.3_GodotEnvironment.md]]"
+    - "[[14.4_ReactiveSystem.md]]"
+    - "[[14.5_StateManagement.md]]"
+    - "[[14.10_UILayout.md]]"
+    - "[[14.13_TechnicalDesignSpec.md]]"
+    - "[[14.18_SystemArchitecture.md]]"
+    - "[[15.1_ReactiveSystemImpl.md]]"
+    - "[[15.2_StateManagementImpl.md]]"
+    - "[[15.3_EnemyAISpec.md]]"
+    - "[[15.4_CombatSystemSpec.md]]"
+    - "[[15.5_SkillSystemSpec.md]]"
+    - "[[15.6_SaveLoadSpec.md]]"
 ---
 
 # UI/UX Implementation Specification

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.8_TestPerformanceSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.8_TestPerformanceSpec.md
@@ -1,31 +1,30 @@
 ---
-title: Test and Performance Implementation Specification
+title: テスト・パフォーマンス実装仕様
 version: 0.3
 status: approved
-updated: 2025-06-07
+updated: 2025-06-06
 tags:
     - Implementation
     - Test
     - Performance
-related_tech_docs:
-    - 14.1_Requirement.md
-    - 14.2_PrototypeTechnicalDesign.md
-    - 14.3_GodotEnvironment.md
-    - 14.4_ReactiveSystem.md
-    - 14.5_StateManagement.md
-    - 14.11_TestAutomation.md
-    - 14.12_PerformanceProfiling.md
-    - 14.13_TechnicalDesignSpec.md
-    - 14.18_SystemArchitecture.md
-related_impl_specs:
-    - 15.1_ReactiveSystemImpl.md
-    - 15.2_StateManagementImpl.md
-    - 15.3_EnemyAISpec.md
-    - 15.4_CombatSystemSpec.md
-    - 15.5_SkillSystemSpec.md
-    - 15.6_SaveLoadSpec.md
-    - 15.7_UIUXSpec.md
-    - 15.12_PerformanceOptimizationSpec.md
+linked_docs:
+    - "[[14.1_Requirement.md]]"
+    - "[[14.2_PrototypeTechnicalDesign.md]]"
+    - "[[14.3_GodotEnvironment.md]]"
+    - "[[14.4_ReactiveSystem.md]]"
+    - "[[14.5_StateManagement.md]]"
+    - "[[14.11_TestAutomation.md]]"
+    - "[[14.12_PerformanceProfiling.md]]"
+    - "[[14.13_TechnicalDesignSpec.md]]"
+    - "[[14.18_SystemArchitecture.md]]"
+    - "[[15.1_ReactiveSystemImpl.md]]"
+    - "[[15.2_StateManagementImpl.md]]"
+    - "[[15.3_EnemyAISpec.md]]"
+    - "[[15.4_CombatSystemSpec.md]]"
+    - "[[15.5_SkillSystemSpec.md]]"
+    - "[[15.6_SaveLoadSpec.md]]"
+    - "[[15.7_UIUXSpec.md]]"
+    - "[[15.12_PerformanceOptimizationSpec.md]]"
 ---
 
 # テスト・パフォーマンス実装仕様

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.9_AccessibilitySpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.9_AccessibilitySpec.md
@@ -2,11 +2,13 @@
 title: アクセシビリティ実装仕様
 version: 0.3
 status: approved
-updated: 2025-06-07
+updated: 2025-06-06
 tags:
     - Implementation
     - Accessibility
     - UI
+linked_docs:
+    - "[[15.7_UIUXSpec.md]]"
 ---
 
 # アクセシビリティ実装仕様


### PR DESCRIPTION
## Summary
- add `linked_docs` metadata field to all implementation specs
- switch titles to Japanese and update outdated docs
- bump versions and approval status where necessary

## Testing
- `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68428492e5e88323b1a38d2dba711f95