### PR TITLE
Fix document metadata

### DIFF
--- a/Docs/10_CoreDocs/11_PlanDocs/11_8_risk_matrix.md
+++ b/Docs/10_CoreDocs/11_PlanDocs/11_8_risk_matrix.md
@@ -1,8 +1,13 @@
 ---
 title: 08_RiskMatrix
-version: 0.1
+version: 0.1.0
 status: draft
 updated: 2025-05-30
+tags:
+    - Risk
+    - Management
+linked_docs:
+    - "[[11_1_plan]]"
 ---
 
 | リスク                             | 発生確率 | 影響度 | 優先度 | 対策                                 |

--- a/Docs/10_CoreDocs/12_Job/12.1_Shadowbinder.md
+++ b/Docs/10_CoreDocs/12_Job/12.1_Shadowbinder.md
@@ -1,16 +1,15 @@
 ---
 title: 11_Shadowbinder
-version: 0.2
+version: 0.2.0
 status: draft
 updated: 2025-05-29
 tags:
-  - Document
+    - Document
 linked_docs:
-  - 11.1_Plan
-  - 13.1_SkilData
+    - "[[11_1_plan]]"
+    - "[[13_1_skill_data]]"
 ---
 
----
 
 # 影使い ── Shadowbinder (初期ジョブ)
 
@@ -94,7 +93,6 @@ flowchart LR
 -   スタミナ消費と回復速度 (テンポ調整)。
 -   影界侵入中の被弾判定／UI 表現。
 
----
 
 > **次ステップ**: v0.1 数値を Godot へ実装 → プロファイラでフレーム計測し、CoreExperienceSpec と突合。疑問が出たらこのドキュメントを更新してください。
 

--- a/Docs/10_CoreDocs/15_ImplementationSpecs/15.21_ErrorHandlingSpec.md
+++ b/Docs/10_CoreDocs/15_ImplementationSpecs/15.21_ErrorHandlingSpec.md
@@ -1,6 +1,6 @@
 ---
 title: エラー処理実装仕様
-version: 0.2
+version: 0.2.0
 status: approved
 updated: 2025-06-07
 tags:
@@ -8,15 +8,15 @@ tags:
     - Error
     - Debug
 linked_docs:
-    - "[[14.1_Requirement.md]]"
-    - "[[14.2_PrototypeTechnicalDesign.md]]"
-    - "[[14.13_TechnicalDesignSpec.md]]"
-    - "[[15.8_TestPerformanceSpec.md]]"
-    - "[[15.12_PerformanceOptimizationSpec.md]]"
-    - "[[15.15_TestErrorGuidelines.md]]"
-    - "[[15.24_PerformanceSettingsSpec.md]]"
-    - "[[15.25_DebugFeaturesSpec.md]]"
-    - "[[15.27_AssetManagementSpec.md]]"
+    - "[[14.1_Requirement]]"
+    - "[[14.2_PrototypeTechnicalDesign]]"
+    - "[[14.13_TechnicalDesignSpec]]"
+    - "[[15.8_TestPerformanceSpec]]"
+    - "[[15.12_PerformanceOptimizationSpec]]"
+    - "[[15.15_TestErrorGuidelines]]"
+    - "[[15.24_PerformanceSettingsSpec]]"
+    - "[[15.25_DebugFeaturesSpec]]"
+    - "[[15.27_AssetManagementSpec]]"
 ---
 
 # エラー処理とデバッグ機能実装仕様


### PR DESCRIPTION
## Summary
- fix Shadowbinder job document metadata
- correct links and version in error handling spec
- add missing metadata to risk matrix doc

## Testing
- `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429c057d908323bd1a4eb9fb3a2732