### PR TITLE
Add CLI setup step in implementation workflow

### DIFF
--- a/Docs/10_CoreDocs/14_TechDocs/14.3_GodotEnvironment.md
+++ b/Docs/10_CoreDocs/14_TechDocs/14.3_GodotEnvironment.md
@@ -1,6 +1,6 @@
 ---
 title: Godot Environment Setup
-version: 0.3
+version: 0.6
 status: approved
 updated: 2025-06-06
 tags:
@@ -60,6 +60,11 @@ linked_docs:
 - Visual Studio Code
 - Git
 - GitHub Desktop
+- Godot CLI (Linux x86_64)
+  - `setup_godot_cli.sh` スクリプトでインストール
+  - スクリプト実行時に `godot --headless --import` を自動実行し、必要なアセットを
+    事前にインポート
+  - `godot --version` で動作確認
 
 ### 2. 推奨スペック
 - OS: Windows 10/11
@@ -193,6 +198,9 @@ GodotGame/
 
 | バージョン | 更新日     | 変更内容                 |
 | ---------- | ---------- | ------------------------ |
+| 0.6        | 2025-06-06 | setupスクリプトに資産インポートを追加 |
+| 0.5        | 2025-06-06 | setup_godot_cli.sh 追加 |
+| 0.4        | 2025-06-06 | Godot CLI 利用手順を追記 |
 | 0.3        | 2025-06-07 | プロジェクト設定を詳細化 |
 | 0.2        | 2025-05-29 | テンプレート統一化       |
 | 0.1.0      | 2025-05-28 | 初版作成                 |

--- a/Docs/99_Reference/AI_Agent_ImplementationWorkflow.md
+++ b/Docs/99_Reference/AI_Agent_ImplementationWorkflow.md
@@ -1,6 +1,6 @@
 ---
 title: AIエージェント向け実装ワークフロー
-version: 0.2
+version: 0.3
 status: draft
 updated: 2025-06-06
 tags:
@@ -32,6 +32,7 @@ linked_docs:
 
 1. **環境セットアップ**
     - [[14_TechDocs/14.3_GodotEnvironment.md|Godot環境設定]]に従って必要なソフトウェアを準備します。
+    - `setup_godot_cli.sh` を実行して Godot CLI をインストールし、アセットをインポートします。
     - テスト自動化のために[[14_TechDocs/14.11_TestAutomation.md|テスト自動化システム]]の手順も確認します。
 2. **コアシステム実装**
     - [[15_ImplementationSpecs/15.1_InputManagementSpec.md|入力管理]]、[[15_ImplementationSpecs/15.1_ReactiveSystemImpl.md|リアクティブシステム]]、[[15_ImplementationSpecs/15.2_StateManagementImpl.md|状態管理]]を最優先で実装します。
@@ -68,5 +69,6 @@ linked_docs:
 
 | バージョン | 更新日     | 変更内容 |
 | ---------- | ---------- | -------- |
+| 0.3        | 2025-06-06 | Godot CLI セットアップ手順を追記 |
 | 0.2        | 2025-06-06 | 実装ワークフロー詳細を追記 |
 | 0.1        | 2025-06-06 | 初版作成 |

--- a/setup_godot_cli.sh
+++ b/setup_godot_cli.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+VERSION="4.4.1"
+URL="https://github.com/godotengine/godot/releases/download/${VERSION}-stable/Godot_v${VERSION}-stable_linux.x86_64.zip"
+if command -v godot >/dev/null 2>&1; then
+    echo "godot is already installed: $(godot --version)"
+else
+    TMP_DIR=$(mktemp -d)
+    cd "$TMP_DIR"
+    curl -L -o godot.zip "$URL"
+    unzip -q godot.zip
+    sudo mv Godot_v${VERSION}-stable_linux.x86_64 /usr/local/bin/godot
+    sudo chmod +x /usr/local/bin/godot
+    cd -
+    rm -rf "$TMP_DIR"
+    echo "Godot CLI installed to /usr/local/bin/godot"
+fi
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+godot --headless --path "$PROJECT_DIR" --import
+echo "Assets imported for project at $PROJECT_DIR"


### PR DESCRIPTION
## Summary
- document running `setup_godot_cli.sh` before development
- bump implementation workflow version to 0.3

## Testing
- `bash setup_godot_cli.sh`
- `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6842ac48d6488323a10e6585ebbceda5