### PR TITLE
Docker設定の整理

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,44 +10,47 @@ RUN apt-get update && apt-get install -y \
     software-properties-common \
     apt-transport-https \
     ca-certificates \
-    x11-apps \
-    && rm -rf /var/lib/apt/lists/*
+    x11-apps && \
+    rm -rf /var/lib/apt/lists/*
 
-# Node.jsのインストール（Cursor IDE用）
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
-    && apt-get install -y nodejs
+# Node.js 18 のインストール（Cursor IDE用）
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs
 
-# Cursor IDEのインストール
-RUN wget https://download.cursor.sh/linux/appImage/x64/cursor-0.1.0.AppImage \
-    && chmod +x cursor-0.1.0.AppImage \
-    && mv cursor-0.1.0.AppImage /usr/local/bin/cursor
+# .NET 8 SDK のインストール
+RUN wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    rm packages-microsoft-prod.deb && \
+    apt-get update && \
+    apt-get install -y dotnet-sdk-8.0 && \
+    rm -rf /var/lib/apt/lists/*
 
-# Godot Engine 4.4のインストール
-RUN wget https://github.com/godotengine/godot/releases/download/4.4-stable/Godot_v4.4-stable_linux.x86_64.zip \
-    && unzip Godot_v4.4-stable_linux.x86_64.zip \
-    && mv Godot_v4.4-stable_linux.x86_64 /usr/local/bin/godot \
-    && rm Godot_v4.4-stable_linux.x86_64.zip
+# Cursor IDE のインストール
+RUN wget https://download.cursor.sh/linux/appImage/x64/cursor-0.1.0.AppImage && \
+    chmod +x cursor-0.1.0.AppImage && \
+    mv cursor-0.1.0.AppImage /usr/local/bin/cursor
 
-# Obsidianのインストール
-RUN wget https://github.com/obsidianmd/obsidian-releases/releases/download/v1.5.8/obsidian_1.5.8_amd64.deb \
-    && apt-get install -y ./obsidian_1.5.8_amd64.deb \
-    && rm obsidian_1.5.8_amd64.deb
+# Godot Engine 4.4.1 のインストール
+RUN wget https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_linux.x86_64.zip && \
+    unzip Godot_v4.4.1-stable_linux.x86_64.zip && \
+    mv Godot_v4.4.1-stable_linux.x86_64 /usr/local/bin/godot && \
+    rm Godot_v4.4.1-stable_linux.x86_64.zip
 
-# 作業ディレクトリの設定
+# Obsidian のインストール
+RUN wget https://github.com/obsidianmd/obsidian-releases/releases/download/v1.5.8/obsidian_1.5.8_amd64.deb && \
+    apt-get install -y ./obsidian_1.5.8_amd64.deb && \
+    rm obsidian_1.5.8_amd64.deb
+
 WORKDIR /workspace
 
-# プロジェクトファイルのコピー
 COPY . .
 
-# 環境変数の設定
 ENV GODOT_EDITOR_PATH=/usr/local/bin/godot
 ENV CURSOR_PATH=/usr/local/bin/cursor
 ENV OBSIDIAN_PATH=/usr/bin/obsidian
 
-# 設定ファイルの配置
-RUN mkdir -p /root/.config/godot \
-    && mkdir -p /root/.config/Cursor \
-    && mkdir -p /root/.config/obsidian
+RUN mkdir -p /root/.config/godot && \
+    mkdir -p /root/.config/Cursor && \
+    mkdir -p /root/.config/obsidian
 
-# デフォルトコマンド
-CMD ["godot", "--editor"] 
+CMD ["godot", "--editor"]

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@
 
 ```bash
 git clone [リポジトリのURL]
-cd newgameproject
+cd GodotGame
 ```
 
 2. 開発環境の起動
 
 ```bash
-docker-compose up
+docker-compose up --build
 ```
 
 ## 利用可能なツール


### PR DESCRIPTION
## 変更内容
- Dockerfile を再構成して .NET 8 SDK と Godot 4.4.1 を導入
- README の手順を `cd GodotGame` と `docker-compose up --build` に修正

## テスト方法
- `./setup_godot_cli.sh` を実行して Godot CLI をインストール
- `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json` を実行

## 関連 Issue
- なし

------
https://chatgpt.com/codex/tasks/task_e_6842b55e2ac483238102598d5f4920f2