### PR TITLE
Add develop target to AGENT instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENT Instructions
+
+When creating pull request messages, read and follow the guidelines in `Docs/99_Reference/PullRequestProcedure.md`.
+Unless another target is specified, open pull requests against the `develop` branch.
+


### PR DESCRIPTION
## 変更内容
- AGENTS.md に develop ブランチをデフォルトのマージ先として明記しました。

## 主な変更点
1. ドキュメント
    - PR 作成時に `develop` ブランチをターゲットにする旨を追記

## テスト方法
- `git status` で作業ツリーがクリーンであることを確認


------
https://chatgpt.com/codex/tasks/task_e_6842ffef5d54832387328c83426e597c