### PR TITLE
Fix StateManager history

### DIFF
--- a/Docs/20_UserGuides/TestExecutionGuide.md
+++ b/Docs/20_UserGuides/TestExecutionGuide.md
@@ -1,8 +1,8 @@
 ---
 title: テスト実行ガイド
-version: 0.2.2
+version: 0.2.3
 status: draft
-updated: 2025-06-06
+updated: 2025-06-07
 tags:
     - UserGuide
     - Test
@@ -47,11 +47,13 @@ godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json
 1. C# スクリプトを追加した後は `godot --headless --path . --build-solutions --quit` を実行して DLL を生成してください。
 2. テストスクリプトは GDScript で記述できます。C# クラスを参照する場合は `[GlobalClass]` 属性を利用し、メソッド名の大文字・小文字に気を付けます。
 3. `.NET SDK` が無い環境では Godot の Mono 版が起動できません。必要に応じて `apt-get install dotnet-sdk-8.0` を実行してください。
+4. テスト実行時に `Nonexistent function` などのエラーが表示された場合は、ソリューションが未ビルドの可能性があります。`godot --headless --path . --build-solutions --quit` を再度実行してからテストを行ってください。
 
 ## 変更履歴
 
 | バージョン | 更新日     | 変更内容 |
 | ---------- | ---------- | -------- |
+| 0.2.3      | 2025-06-07 | テスト実行時エラー対処法を追加 |
 | 0.2.2      | 2025-06-06 | apt 更新と .NET インストール手順を追加 |
 | 0.2.1      | 2025-06-06 | setup スクリプトの前提条件を追記 |
 | 0.2.0      | 2025-06-06 | テスト時の注意点を追記 |

--- a/Scripts/Core/StateManager.cs
+++ b/Scripts/Core/StateManager.cs
@@ -51,9 +51,17 @@ public partial class StateManager : Node
     }
 
     // 履歴を取得する
-    public IList<Variant> GetStateHistory(string state_name)
+    public Godot.Collections.Array GetStateHistory(string state_name)
     {
-        return state_history.TryGetValue(state_name, out var history) ? history : new List<Variant>();
+        var result = new Godot.Collections.Array();
+        if (state_history.TryGetValue(state_name, out var history))
+        {
+            foreach (var value in history)
+            {
+                result.Add(value);
+            }
+        }
+        return result;
     }
 }
 


### PR DESCRIPTION
## Summary
- C# `StateManager` の履歴取得を `Godot.Collections.Array` で返すよう修正
- テスト実行ガイドにビルドが必要な場合の対処を追記

## Testing
- `dotnet build NewGameProject.sln`
- `godot --headless --build-solutions --quit`
- `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6843184dc58083238a2a6863ec92e7b7