### PR TITLE
Fix GUT warnings by freeing nodes

### DIFF
--- a/Scripts/Tests/Core/test_event_bus.gd
+++ b/Scripts/Tests/Core/test_event_bus.gd
@@ -9,7 +9,7 @@ func before_each() -> void:
     received = null
 
 func after_each() -> void:
-    bus.queue_free()
+    bus.free()
 
 func _on_event(data: Dictionary) -> void:
     received = data

--- a/Scripts/Tests/Core/test_input_buffer.gd
+++ b/Scripts/Tests/Core/test_input_buffer.gd
@@ -7,7 +7,7 @@ func before_each() -> void:
     add_child(buffer)
 
 func after_each() -> void:
-    buffer.queue_free()
+    buffer.free()
 
 func test_enqueue_dequeue() -> void:
     var event_a := InputEventKey.new()

--- a/Scripts/Tests/Core/test_player_state_machine.gd
+++ b/Scripts/Tests/Core/test_player_state_machine.gd
@@ -14,8 +14,8 @@ func before_each() -> void:
     bus.Subscribe("PlayerStateChanged", Callable(self, "_on_state_change"))
 
 func after_each() -> void:
-    fsm.queue_free()
-    bus.queue_free()
+    fsm.free()
+    bus.free()
 
 func _on_state_change(data: Dictionary) -> void:
     received = data

--- a/Scripts/Tests/Core/test_state_manager.gd
+++ b/Scripts/Tests/Core/test_state_manager.gd
@@ -7,7 +7,7 @@ func before_each() -> void:
     add_child(manager)
 
 func after_each() -> void:
-    manager.queue_free()
+    manager.free()
 
 func test_set_get_has_remove() -> void:
     manager.SetState("score", 10)


### PR DESCRIPTION
## 変更点
- テスト終了時に `queue_free()` を使用していた箇所を `free()` に変更し、未解放ノード警告を抑制

## テスト方法
1. `setup_godot_cli.sh` で Godot CLI をインストール
2. `godot --headless --path . --build-solutions --quit` でソリューションをビルド
3. `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json` を実行

テスト実行時に C# クラスが認識されず Parse Error が発生するため、テスト結果の確認は行えませんでした。

------
https://chatgpt.com/codex/tasks/task_e_68431e2b3ea88323a691bb525fc15302