### PR TITLE
fix: setup and doc improvements

### DIFF
--- a/Docs/10_CoreDocs/14_TechDocs/14.3_GodotEnvironment.md
+++ b/Docs/10_CoreDocs/14_TechDocs/14.3_GodotEnvironment.md
@@ -1,8 +1,8 @@
 ---
 title: Godot Environment Setup
-version: 0.7
+version: 0.8
 status: approved
-updated: 2025-06-06
+updated: 2025-06-07
 tags:
     - Technical
     - Environment
@@ -61,11 +61,8 @@ linked_docs:
 - Git
 - GitHub Desktop
 - Godot CLI (Linux x86_64)
-  - `setup_godot_cli.sh` スクリプトでインストール
-  - 実行には `.NET SDK` 8.0 以上が必要
-  - スクリプト実行時に `godot --headless --import` を自動実行し、必要なアセットを
-    事前にインポート
-  - インストール後は `godot --headless --path . --build-solutions --quit` でソリューションをビルド
+  - `setup_godot_cli.sh` スクリプトでインストール（`.NET SDK` も自動導入）
+  - スクリプト実行時に `godot --headless --import` と `--build-solutions` を自動で実行し、必要なアセットのインポートとビルドを行う
   - `godot --version` で動作確認
 
 ### 2. 推奨スペック
@@ -200,6 +197,7 @@ GodotGame/
 
 | バージョン | 更新日     | 変更内容                 |
 | ---------- | ---------- | ------------------------ |
+| 0.8        | 2025-06-07 | setup_godot_cli.sh の自動インストール更新 |
 | 0.7        | 2025-06-06 | setup スクリプトの依存関係を追記 |
 | 0.6        | 2025-06-06 | setupスクリプトに資産インポートを追加 |
 | 0.5        | 2025-06-06 | setup_godot_cli.sh 追加 |

--- a/Docs/20_UserGuides/TestExecutionGuide.md
+++ b/Docs/20_UserGuides/TestExecutionGuide.md
@@ -1,6 +1,6 @@
 ---
 title: テスト実行ガイド
-version: 0.2.3
+version: 0.2.4
 status: draft
 updated: 2025-06-07
 tags:
@@ -26,9 +26,9 @@ linked_docs:
 
 ## 環境構築
 
-1. `sudo apt-get update` を実行してパッケージを最新化した後、`sudo apt-get install -y dotnet-sdk-8.0` で `.NET SDK` 8.0 以上をインストールします。
-2. `setup_godot_cli.sh` を実行して C# 対応の Godot CLI をインストールします。スクリプトは .NET ランタイムが無いと失敗します。
-3. インストール後、`godot --headless --path . --build-solutions --quit` を実行してソリューションをビルドし、アセットをインポートします。
+1. `sudo apt-get update` を実行してパッケージを最新化します。
+2. `setup_godot_cli.sh` を実行すると `.NET SDK` と Godot CLI が自動でインストールされ、ソリューションのビルドも行われます。
+3. スクリプト実行後はアセットがインポートされた状態となります。
 
 ## テスト実行
 
@@ -46,13 +46,14 @@ godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json
 
 1. C# スクリプトを追加した後は `godot --headless --path . --build-solutions --quit` を実行して DLL を生成してください。
 2. テストスクリプトは GDScript で記述できます。C# クラスを参照する場合は `[GlobalClass]` 属性を利用し、メソッド名の大文字・小文字に気を付けます。
-3. `.NET SDK` が無い環境では Godot の Mono 版が起動できません。必要に応じて `apt-get install dotnet-sdk-8.0` を実行してください。
+3. `.NET SDK` が無い環境では Godot の Mono 版が起動できません。`setup_godot_cli.sh` 実行時に自動インストールされますが、失敗した場合は `apt-get install dotnet-sdk-8.0` を手動で実行してください。
 4. テスト実行時に `Nonexistent function` などのエラーが表示された場合は、ソリューションが未ビルドの可能性があります。`godot --headless --path . --build-solutions --quit` を再度実行してからテストを行ってください。
 
 ## 変更履歴
 
 | バージョン | 更新日     | 変更内容 |
 | ---------- | ---------- | -------- |
+| 0.2.4      | 2025-06-07 | setup_godot_cli.sh の自動インストール対応 |
 | 0.2.3      | 2025-06-07 | テスト実行時エラー対処法を追加 |
 | 0.2.2      | 2025-06-06 | apt 更新と .NET インストール手順を追加 |
 | 0.2.1      | 2025-06-06 | setup スクリプトの前提条件を追記 |

--- a/Docs/20_UserGuides/TestGuidelines.md
+++ b/Docs/20_UserGuides/TestGuidelines.md
@@ -1,8 +1,8 @@
 ---
 title: テストガイドライン
-version: 0.1.2
+version: 0.1.3
 status: draft
-updated: 2025-06-06
+updated: 2025-06-07
 tags:
     - UserGuide
     - Test
@@ -34,12 +34,8 @@ linked_docs:
 ## テスト実行手順
 
 1. `sudo apt-get update` を実行し、パッケージリストを最新化します。
-2. `sudo apt-get install -y dotnet-sdk-8.0` で `.NET SDK 8.0` 以上をインストールします。
-3. `setup_godot_cli.sh` を実行して Godot CLI を導入します。
-4. `godot --headless --path . --import` を一度実行し、アセットをインポートします。
-5. `dotnet build` を実行してソリューションをビルドします。
-6. 生成された DLL を `.godot/mono/assemblies/Debug/` にコピーします。
-7. 下記コマンドでテストを実行します。
+2. `setup_godot_cli.sh` を実行すると `.NET SDK` と Godot CLI がまとめて導入され、アセットインポートとソリューションビルドまで自動で行われます。
+3. 下記コマンドでテストを実行します。
 
 ```bash
 godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json
@@ -55,6 +51,7 @@ godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json
 
 | バージョン | 更新日     | 変更内容 |
 | ---------- | ---------- | -------- |
+| 0.1.3      | 2025-06-07 | setup_godot_cli.sh の自動化に伴い手順を簡素化 |
 | 0.1.2      | 2025-06-06 | setup_godot_cli.sh 実行前の apt 更新と .NET インストールを追記 |
 | 0.1.1      | 2025-06-06 | インポート手順を追記 |
 | 0.1.0      | 2025-06-06 | 初版作成 |

--- a/setup_godot_cli.sh
+++ b/setup_godot_cli.sh
@@ -2,6 +2,10 @@
 set -e
 VERSION="4.4.1"
 URL="https://github.com/godotengine/godot/releases/download/${VERSION}-stable/Godot_v${VERSION}-stable_mono_linux_x86_64.zip"
+if ! command -v dotnet >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y dotnet-sdk-8.0
+fi
 if command -v godot >/dev/null 2>&1; then
     echo "godot is already installed: $(godot --version)"
 else
@@ -18,4 +22,5 @@ else
 fi
 PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
 godot --headless --path "$PROJECT_DIR" --import
+godot --headless --path "$PROJECT_DIR" --build-solutions --quit
 echo "Assets imported for project at $PROJECT_DIR"


### PR DESCRIPTION
## 変更内容
- `setup_godot_cli.sh` に .NET SDK の自動インストールとソリューションビルド処理を追加
- テスト関連ドキュメントを更新し、セットアップ手順の簡素化を反映
- Godot 環境設定ドキュメントを修正し、自動インストールに対応

## テスト方法
- `setup_godot_cli.sh` 実行後、`godot --headless --path . --build-solutions -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json` を実行しテストが全て成功することを確認

## 関連 Issue
- なし

------
https://chatgpt.com/codex/tasks/task_e_6843b27b3dc48323b629c2d012cdc151