### PR TITLE
Fix build by avoiding duplicate compile items

### DIFF
--- a/NewGameProject.csproj
+++ b/NewGameProject.csproj
@@ -2,5 +2,9 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Scripts/**/*.cs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## 変更点
- `NewGameProject.csproj`でデフォルトのコンパイル対象を無効化し、`Scripts`フォルダーのみを明示的に指定

## テスト方法
- `dotnet clean NewGameProject.csproj`
- `dotnet build NewGameProject.csproj -c Debug`
- `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json`

以上がすべて成功することを確認しました。

------
https://chatgpt.com/codex/tasks/task_e_6843b53fafb88323b4ff12d9bd7120c0