### PR TITLE
Fix CI action path

### DIFF
--- a/.github/workflows/Godot_CI.yml
+++ b/.github/workflows/Godot_CI.yml
@@ -16,9 +16,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Godot
-        uses: firebelley/setup-godot@v1.3
+        uses: lihop/godot-setup@v2
         with:
-          version: 4.4.1  # ←使っているGodotのバージョンに合わせてください
+          version: 4.4.1
 
       - name: Run headless Godot build
         run: godot --headless --editor --quit


### PR DESCRIPTION
## Summary
- use `lihop/godot-setup@v2` instead of the removed action

## Testing
- `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e800c8e48323bec52d398999e68a