### PR TITLE
Fix float warning in state manager tests

### DIFF
--- a/Scripts/Core/StateManager.cs
+++ b/Scripts/Core/StateManager.cs
@@ -162,8 +162,7 @@ public partial class StateManager : Node
         {
             dict[kv.Key] = kv.Value;
         }
-        var json = Json.Stringify(dict);
-        file.StoreString(json);
+        file.StoreVar(dict);
     }
 
     public void LoadAll(string path)
@@ -177,8 +176,7 @@ public partial class StateManager : Node
         {
             return;
         }
-        var json = file.GetAsText();
-        var variant = Json.ParseString(json);
+        var variant = file.GetVar();
         if (variant.VariantType != Variant.Type.Dictionary)
         {
             return;


### PR DESCRIPTION
## Summary
- adjust `StateManager.SaveAll` and `LoadAll` to use `StoreVar`/`GetVar`
- preserve numeric types when persisting states

## Testing
- `dotnet build`
- `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6843ea3b1ff48323a32c1c88cac97ff3