### PR TITLE
Add MVVM design reference in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,9 @@
 - クラス名はパスカルケース、変数名はスネークケース、定数は大文字スネークケースとします。詳細な命名規則は `Docs/10_CoreDocs/DevelopmentGuidelines.md` を参照してください。
 - コードは読みやすさと保守性を重視し、不要な処理や曖昧な表現は避けます。
 
+## 設計
+- 新規機能やシステム設計を行う際は、`Docs/10_CoreDocs/14_TechDocs/14.19_MVVMReactiveDesign.md` を参照し、MVVM + リアクティブプログラミングの方針に沿ってください。
+
 ## ドキュメント
 - `Docs/` 以下の Markdown を更新する際は `Docs/99_Reference/DocumentManagementRules.md` の指針に従います。
     - 冒頭に `title`、`version`、`status`、`updated`、`tags`、`linked_docs` を含む YAML メタデータを記述します。

--- a/Docs/10_CoreDocs/14_TechDocs/00_index.md
+++ b/Docs/10_CoreDocs/14_TechDocs/00_index.md
@@ -1,6 +1,6 @@
 ---
 title: 技術ドキュメント
-version: 0.4.1
+version: 0.4.2
 status: draft
 updated: 2025-06-07
 tags:
@@ -25,6 +25,7 @@ linked_docs:
 - "[[14.16_SoundManager.md]]"
 - "[[14.17_DebugManager.md]]"
 - "[[14.18_SystemArchitecture.md]]"
+- "[[14.19_MVVMReactiveDesign.md]]"
 - "[[15.1_ReactiveSystemImpl.md]]"
 - "[[15.2_StateManagementImpl.md]]"
 - "[[15.3_EnemyAISpec.md]]"
@@ -80,6 +81,7 @@ linked_docs:
 
 ### 5. アーキテクチャ
 - [14.18 システムアーキテクチャ](14.18_SystemArchitecture.md) - 全体システムアーキテクチャ
+- [14.19 MVVM + リアクティブ設計ガイド](14.19_MVVMReactiveDesign.md) - MVVMとリアクティブプログラミングの方針
 
 ## 使用方法
 

--- a/Docs/10_CoreDocs/14_TechDocs/14.18_SystemArchitecture.md
+++ b/Docs/10_CoreDocs/14_TechDocs/14.18_SystemArchitecture.md
@@ -1,6 +1,6 @@
 ---
 title: System Architecture
-version: 0.4
+version: 0.5
 status: approved
 updated: 2025-06-07
 tags:
@@ -25,6 +25,7 @@ linked_docs:
 - "[[14.16_SoundManager.md]]"
 - "[[14.17_DebugManager.md]]"
 - "[[14.18_SystemArchitecture.md]]"
+- "[[14.19_MVVMReactiveDesign.md]]"
 - "[[15.1_ReactiveSystemImpl.md]]"
 - "[[15.2_StateManagementImpl.md]]"
 - "[[15.3_EnemyAISpec.md]]"
@@ -65,6 +66,12 @@ linked_docs:
 - イベント駆動型
 - コンポーネントベース
 - サービス指向
+
+### 3. MVVM + リアクティブ設計
+- ViewModel を中心に状態を管理し、`INotifyPropertyChanged` などで変化を通知
+- 入力や非同期イベントをストリーム化して宣言的に処理
+- Model ⇄ ViewModel 間は基本的に一方向とし、UI からの即時反映はコマンド経由で行う
+- 詳細は [14.19 MVVM + リアクティブ設計ガイド](14.19_MVVMReactiveDesign.md) を参照
 
 ## アーキテクチャ
 

--- a/Docs/10_CoreDocs/14_TechDocs/14.19_MVVMReactiveDesign.md
+++ b/Docs/10_CoreDocs/14_TechDocs/14.19_MVVMReactiveDesign.md
@@ -1,0 +1,76 @@
+---
+title: MVVM + リアクティブ設計ガイド
+version: 0.1.0
+status: draft
+updated: 2025-06-07
+tags:
+  - Technical
+  - Architecture
+  - Reactive
+  - MVVM
+linked_docs:
+  - "[[14.18_SystemArchitecture.md]]"
+  - "[[14.15_UIManager.md]]"
+  - "[[15.1_ReactiveSystemImpl.md]]"
+  - "[[15.2_StateManagementImpl.md]]"
+---
+
+# MVVM + リアクティブ設計ガイド
+
+## 目次
+1. [概要](#概要)
+2. [設計思想](#設計思想)
+3. [レイヤー構造](#レイヤー構造)
+4. [開発フロー](#開発フロー)
+5. [関連ドキュメント](#関連ドキュメント)
+6. [変更履歴](#変更履歴)
+
+## 概要
+
+本ドキュメントでは、Godot で C# を用いて MVVM とリアクティブプログラミングを統合するための基本方針を示す。UI ロジックとゲームロジックを分離し、宣言的な状態管理を行うことで、保守性の高いアーキテクチャを実現する。
+
+## 設計思想
+
+### MVVM とリアクティブの統合
+- ViewModel を状態ハブとして設計し `INotifyPropertyChanged` または独自 Observable で状態変化を通知する。
+- 入力、時間経過、非同期イベントをストリームとして扱い、宣言的に処理を記述する。
+- Model から View へのデータ流を基本とし、UI 側の即時反映が必要な場合のみ双方向バインディングを行う。
+
+### ゲーム開発における利点
+- UI とゲームロジックの結合度を下げ変更に強い構成とする。
+- ステートマシンと組み合わせることで状態遷移を明確化できる。
+- イベント伝播をストリーム化することで複雑な同期処理を削減できる。
+
+### OOP との共存
+- Model やドメイン層は OOP で記述し、ViewModel と View をリアクティブに構成する。
+- データ伝播は Observable を通して自動反映させ、保守性を高める。
+
+## レイヤー構造
+
+```
+[Input] → View → ViewModel → Model → ViewModel → View → [Draw]
+```
+
+- View は ViewModel の Observable を購読し描画更新を行う。
+- ViewModel は Model からデータを取得し、サービス層を介して非同期処理を実行する。
+- 双方向通信が必要な場合は ViewModel に明示的なコマンドとして実装する。
+
+## 開発フロー
+
+1. Model にゲーム状態やロジックを実装する。
+2. ViewModel で Observable プロパティとコマンドを定義する。
+3. View (Node) は ViewModel を購読し、入力を ViewModel へ通知する。
+4. テストは Model と ViewModel を中心にユニットテストを実施する。
+
+## 関連ドキュメント
+- [14.18 システムアーキテクチャ](14.18_SystemArchitecture.md)
+- [14.15 UIマネージャー](14.15_UIManager.md)
+- [15.1 リアクティブシステム実装仕様](15.1_ReactiveSystemImpl.md)
+- [15.2 状態管理実装仕様](15.2_StateManagementImpl.md)
+
+## 変更履歴
+
+| バージョン | 更新日     | 変更内容 |
+| ---------- | ---------- | -------- |
+| 0.1.0      | 2025-06-07 | 初版作成 |
+


### PR DESCRIPTION
## Summary
- instruct contributors to consult MVVM + reactive design guide when planning features

## Testing
- `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442920c6488323a234f5ca513a547d