### PR TITLE
feat: implement MVVM reactive sample

### DIFF
--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -1,3 +1,6 @@
+
 [gd_scene format=3 uid="uid://d2b2ehk6kx115"]
+[ext_resource type="Script" path="res://Scripts/Main.gd" id="1"]
 
 [node name="Node3D" type="Node3D"]
+script = ExtResource("1")

--- a/Scripts/Core/ObservableProperty.gd
+++ b/Scripts/Core/ObservableProperty.gd
@@ -1,0 +1,27 @@
+class_name ObservableProperty
+extends RefCounted
+
+var _value
+var _observers: Array = []
+
+func _init(initial_value = null) -> void:
+    _value = initial_value
+
+func _get_value():
+    return _value
+
+func _set_value(value):
+    if _value != value:
+        _value = value
+        for obs in _observers:
+            obs.call(value)
+
+var value:
+    get: _get_value
+    set: _set_value
+
+func subscribe(observer: Callable) -> void:
+    _observers.append(observer)
+
+func unsubscribe(observer: Callable) -> void:
+    _observers.erase(observer)

--- a/Scripts/Main.gd
+++ b/Scripts/Main.gd
@@ -1,8 +1,17 @@
 # Main.gd
 extends Node3D
 
-# ゲーム開始時に初期化処理を行うための関数
-func _ready():
-	# ここで初期化処理を記述します
-	# 例: プレイヤーの初期位置設定やスコアのリセットなど
-	print("ゲームの初期化処理を実行します。")
+const MAIN_VIEW_MODEL = preload("res://Scripts/ViewModels/MainViewModel.gd")
+
+var _view_model: MainViewModel
+
+func _ready() -> void:
+    _view_model = MAIN_VIEW_MODEL.new()
+    _view_model.message.subscribe(_on_message_changed)
+    _view_model.set_message("ゲームの初期化処理を実行します。")
+
+func _on_message_changed(text) -> void:
+    print(text)
+
+func _exit_tree() -> void:
+    _view_model.message.unsubscribe(_on_message_changed)

--- a/Scripts/ViewModels/MainViewModel.gd
+++ b/Scripts/ViewModels/MainViewModel.gd
@@ -1,0 +1,8 @@
+class_name MainViewModel
+const ObservableProperty = preload("res://Scripts/Core/ObservableProperty.gd")
+extends Node
+
+@onready var message: ObservableProperty = ObservableProperty.new("")
+
+func set_message(text: String) -> void:
+    message.value = text


### PR DESCRIPTION
## 変更内容

- ObservableProperty を利用する MVVM サンプルを追加
- Main.gd の定数名をスタイルに合わせて修正
- Main.tscn にスクリプト参照を追加

## 主な変更点

1. Scripts
   - `Main.gd` の定数を `MAIN_VIEW_MODEL` に変更し ViewModel を生成
   - `MainViewModel.gd` をロードしてメッセージを購読
2. Scenes
   - `Main.tscn` に `Main.gd` を割り当て

## テスト方法

- `godot --path . --headless --script res://addons/gut/gut_cmdln.gd`
  - コマンドが見つからず実行できず

## 関連 Issue

- なし



------
https://chatgpt.com/codex/tasks/task_e_68442d3fd1a083239ed3bbcd713ba0fa