### PR TITLE
feat: ReactiveCommand<T>追加とPR前調整

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ Docs/.obsidian/workspace.json
 # .NET build outputs
 **/bin/
 **/obj/
+

--- a/Docs/10_CoreDocs/12_Architecture/12_03_detailed_design/01_core_components/01_reactive_property.md
+++ b/Docs/10_CoreDocs/12_Architecture/12_03_detailed_design/01_core_components/01_reactive_property.md
@@ -1,6 +1,6 @@
 ---
 title: ReactiveProperty実装詳細
-version: 0.3.0
+version: 0.3.1
 status: draft
 updated: 2025-06-09
 tags:
@@ -39,6 +39,7 @@ ReactiveProperty は、プロパティの変更を監視し、通知を行うた
 ```csharp
 public class ReactiveProperty<T>
 {
+    private const string VALIDATION_FAILED_MESSAGE = "Validation failed";
     private T _value;
     private readonly Subject<T> _subject = new();
     private readonly List<IDisposable> _disposables = new();
@@ -50,7 +51,7 @@ public class ReactiveProperty<T>
         {
             if (_validator != null && !_validator(value))
             {
-                throw new ArgumentException("Validation failed", nameof(value));
+                throw new ArgumentException(VALIDATION_FAILED_MESSAGE, nameof(value));
             }
             if (!EqualityComparer<T>.Default.Equals(_value, value))
             {
@@ -290,6 +291,7 @@ public void ReactiveProperty_Integration_WorksWithViewModel()
 
 | バージョン | 更新日     | 変更内容                                                                                           |
 | ---------- | ---------- | -------------------------------------------------------------------------------------------------- |
+| 0.3.1      | 2025-06-09 | バリデーション失敗メッセージを定数化 |
 | 0.3.0      | 2025-06-09 | バリデーション失敗時に例外を送出するよう変更 |
 | 0.2.0      | 2024-03-23 | パフォーマンス最適化の追加<br>- メモリ管理の改善<br>- バッチ更新機能の追加<br>- 値の検証機能の強化 |
 | 0.1.0      | 2024-03-22 | 初版作成<br>- 基本実装の定義<br>- 拡張機能の実装<br>- 使用例の追加                                 |

--- a/Docs/10_CoreDocs/12_Architecture/12_03_detailed_design/01_core_components/01_reactive_property.md
+++ b/Docs/10_CoreDocs/12_Architecture/12_03_detailed_design/01_core_components/01_reactive_property.md
@@ -1,8 +1,8 @@
 ---
 title: ReactiveProperty実装詳細
-version: 0.2.0
+version: 0.3.0
 status: draft
-updated: 2024-03-23
+updated: 2025-06-09
 tags:
     - Core
     - Reactive
@@ -48,6 +48,10 @@ public class ReactiveProperty<T>
         get => _value;
         set
         {
+            if (_validator != null && !_validator(value))
+            {
+                throw new ArgumentException("Validation failed", nameof(value));
+            }
             if (!EqualityComparer<T>.Default.Equals(_value, value))
             {
                 _value = value;
@@ -103,6 +107,8 @@ public class ReactiveProperty<T>
     }
 }
 ```
+
+`SetValidator` で登録した関数が `false` を返した場合、値の設定時に `ArgumentException` が送出されます。
 
 ### 3.2 値の変換
 
@@ -284,5 +290,6 @@ public void ReactiveProperty_Integration_WorksWithViewModel()
 
 | バージョン | 更新日     | 変更内容                                                                                           |
 | ---------- | ---------- | -------------------------------------------------------------------------------------------------- |
+| 0.3.0      | 2025-06-09 | バリデーション失敗時に例外を送出するよう変更 |
 | 0.2.0      | 2024-03-23 | パフォーマンス最適化の追加<br>- メモリ管理の改善<br>- バッチ更新機能の追加<br>- 値の検証機能の強化 |
 | 0.1.0      | 2024-03-22 | 初版作成<br>- 基本実装の定義<br>- 拡張機能の実装<br>- 使用例の追加                                 |

--- a/Docs/10_CoreDocs/12_Architecture/12_03_detailed_design/01_core_components/02_viewmodel_base.md
+++ b/Docs/10_CoreDocs/12_Architecture/12_03_detailed_design/01_core_components/02_viewmodel_base.md
@@ -1,6 +1,6 @@
 ---
 title: ViewModelBase実装詳細
-version: 0.2.0
+version: 0.2.1
 status: draft
 updated: 2025-06-09
 tags:
@@ -115,7 +115,7 @@ public abstract class ViewModelBase : IDisposable
 ```csharp
 public abstract class ViewModelBase : IDisposable
 {
-    protected ReactiveProperty<bool> IsBusy { get; } = new(false);
+    protected ReactiveProperty<bool> IsBusy { get; } = new(false).AddTo(Disposables);
 
     protected async Task ExecuteAsync(Func<Task> action)
     {
@@ -158,7 +158,7 @@ public abstract class ViewModelBase : IDisposable
 ```csharp
 public abstract class ViewModelBase : IDisposable
 {
-    public ReactiveProperty<ViewModelState> State { get; } = new(ViewModelState.Initial);
+    public ReactiveProperty<ViewModelState> State { get; } = new(ViewModelState.Initial).AddTo(Disposables);
 
     protected virtual void OnActivate()
     {
@@ -321,5 +321,6 @@ public async Task ViewModelBase_AsyncOperation_UpdatesStateCorrectly()
 
 | バージョン | 更新日     | 変更内容                                                                                                     |
 | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
+| 0.2.1      | 2025-06-09 | IsBusy と State を Disposables に登録 |
 | 0.2.0      | 2025-06-09 | パフォーマンス最適化の追加<br>- メモリ管理の改善<br>- ライフサイクル管理の強化<br>- 非同期処理のサポート追加 |
 | 0.1.0      | 2024-03-22 | 初版作成<br>- 基本実装の定義<br>- コマンド実装の追加<br>- 使用例の追加                                       |

--- a/Docs/10_CoreDocs/12_Architecture/12_03_detailed_design/01_core_components/03_composite_disposable.md
+++ b/Docs/10_CoreDocs/12_Architecture/12_03_detailed_design/01_core_components/03_composite_disposable.md
@@ -1,6 +1,6 @@
 ---
 title: CompositeDisposable実装詳細
-version: 0.1.0
+version: 0.1.1
 status: draft
 updated: 2025-06-09
 tags:
@@ -160,6 +160,19 @@ public class CompositeDisposable : IDisposable
 }
 ```
 
+### 4.1.1 AddTo 拡張
+
+```csharp
+public static class DisposableExtensions
+{
+    public static T AddTo<T>(this T disposable, CompositeDisposable composite) where T : IDisposable
+    {
+        composite.Add(disposable);
+        return disposable;
+    }
+}
+```
+
 ### 4.2 使用例
 
 ```csharp
@@ -276,4 +289,5 @@ public void CompositeDisposable_ConcurrentAccess_ThreadSafe()
 
 | バージョン | 更新日     | 変更内容                                                                                               |
 | ---------- | ---------- | ------------------------------------------------------------------------------------------------------ |
+| 0.1.1      | 2025-06-09 | AddTo 拡張メソッドを追加 |
 | 0.1.0      | 2025-06-09 | 初版作成<br>- 基本実装の定義<br>- スレッドセーフティの実装<br>- テストケースの追加<br>- 制限事項の追加 |

--- a/Docs/10_CoreDocs/12_Architecture/12_03_detailed_design/01_core_components/05_common_utilities.md
+++ b/Docs/10_CoreDocs/12_Architecture/12_03_detailed_design/01_core_components/05_common_utilities.md
@@ -1,6 +1,6 @@
 ---
 title: 共通ユーティリティ実装詳細
-version: 0.2.1
+version: 0.2.2
 status: draft
 updated: 2025-06-09
 tags:
@@ -334,7 +334,7 @@ public static class TaskExtensions
 
     public static async Task<T> WithRetry<T>(this Func<Task<T>> taskFactory, int maxRetries)
     {
-        Exception last = null;
+        Exception last_exception = null;
         for (int i = 0; i < maxRetries; i++)
         {
             try
@@ -343,14 +343,14 @@ public static class TaskExtensions
             }
             catch (Exception ex)
             {
-                last = ex;
+                last_exception = ex;
                 if (i < maxRetries - 1)
                 {
                     await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, i)));
                 }
             }
         }
-        throw last;
+        throw last_exception;
     }
 }
 ```
@@ -400,6 +400,7 @@ public static class TaskExtensions
 
 | バージョン | 更新日     | 変更内容                                                                                                               |
 | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
+| 0.2.2      | 2025-06-09 | WithRetry の変数名を明確化 |
 | 0.2.1      | 2025-06-09 | WithRetry 実装のリトライ回数を修正 |
 | 0.2.0      | 2024-03-23 | 機能拡張<br>- ロギングユーティリティの追加<br>- バリデーションユーティリティの追加<br>- 非同期処理ユーティリティの追加 |
 | 0.1.0      | 2024-03-22 | 初版作成<br>- リアクティブユーティリティの実装<br>- イベントユーティリティの実装<br>- 使用例の追加                     |

--- a/Docs/10_CoreDocs/12_Architecture/12_03_detailed_design/01_core_components/05_common_utilities.md
+++ b/Docs/10_CoreDocs/12_Architecture/12_03_detailed_design/01_core_components/05_common_utilities.md
@@ -1,8 +1,8 @@
 ---
 title: 共通ユーティリティ実装詳細
-version: 0.2.0
+version: 0.2.1
 status: draft
-updated: 2024-03-23
+updated: 2025-06-09
 tags:
     - Core
     - Utility
@@ -334,21 +334,27 @@ public static class TaskExtensions
 
     public static async Task<T> WithRetry<T>(this Func<Task<T>> taskFactory, int maxRetries)
     {
+        Exception last = null;
         for (int i = 0; i < maxRetries; i++)
         {
             try
             {
                 return await taskFactory();
             }
-            catch (Exception) when (i < maxRetries - 1)
+            catch (Exception ex)
             {
-                await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, i)));
+                last = ex;
+                if (i < maxRetries - 1)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, i)));
+                }
             }
         }
-        return await taskFactory();
+        throw last;
     }
 }
 ```
+`maxRetries` 回すべて失敗した場合は最後に捕捉した例外を送出します。
 
 ## 7. ベストプラクティス
 
@@ -394,6 +400,7 @@ public static class TaskExtensions
 
 | バージョン | 更新日     | 変更内容                                                                                                               |
 | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
+| 0.2.1      | 2025-06-09 | WithRetry 実装のリトライ回数を修正 |
 | 0.2.0      | 2024-03-23 | 機能拡張<br>- ロギングユーティリティの追加<br>- バリデーションユーティリティの追加<br>- 非同期処理ユーティリティの追加 |
 | 0.1.0      | 2024-03-22 | 初版作成<br>- リアクティブユーティリティの実装<br>- イベントユーティリティの実装<br>- 使用例の追加                     |
 

--- a/Scripts/Core/Reactive/DisposableExtensions.cs
+++ b/Scripts/Core/Reactive/DisposableExtensions.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Core.Reactive
+{
+    /// <summary>
+    /// IDisposableをCompositeDisposableに追加する拡張メソッド
+    /// </summary>
+    public static class DisposableExtensions
+    {
+        /// <summary>
+        /// CompositeDisposableに登録
+        /// </summary>
+        public static T AddTo<T>(this T disposable, CompositeDisposable composite) where T : IDisposable
+        {
+            composite.Add(disposable);
+            return disposable;
+        }
+    }
+}

--- a/Scripts/Core/Reactive/DisposableExtensions.cs.uid
+++ b/Scripts/Core/Reactive/DisposableExtensions.cs.uid
@@ -1,0 +1,1 @@
+uid://pawynnyllfeh

--- a/Scripts/Core/Reactive/ReactiveProperty.cs
+++ b/Scripts/Core/Reactive/ReactiveProperty.cs
@@ -14,6 +14,7 @@ namespace Core.Reactive
         private readonly Subject<T> _raw_subject = new();
         private readonly ISubject<T> _sync_subject;
         private readonly List<IDisposable> _disposables = new();
+        private const string VALIDATION_FAILED_MESSAGE = "Validation failed";
         private Func<T, bool>? _validator;
         private bool _is_updating;
         private readonly object _sync_lock = new();
@@ -33,7 +34,7 @@ namespace Core.Reactive
                     if (_is_disposed) throw new ObjectDisposedException(nameof(ReactiveProperty<T>));
                     if (_validator != null && !_validator(value))
                     {
-                        throw new ArgumentException("Validation failed", nameof(value));
+                        throw new ArgumentException(VALIDATION_FAILED_MESSAGE, nameof(value));
                     }
                     if (!EqualityComparer<T>.Default.Equals(_value, value))
                     {

--- a/Scripts/Core/Reactive/ReactiveProperty.cs
+++ b/Scripts/Core/Reactive/ReactiveProperty.cs
@@ -31,7 +31,10 @@ namespace Core.Reactive
                 lock (_sync_lock)
                 {
                     if (_is_disposed) throw new ObjectDisposedException(nameof(ReactiveProperty<T>));
-                    if (_validator != null && !_validator(value)) return;
+                    if (_validator != null && !_validator(value))
+                    {
+                        throw new ArgumentException("Validation failed", nameof(value));
+                    }
                     if (!EqualityComparer<T>.Default.Equals(_value, value))
                     {
                         _value = value;

--- a/Scripts/Core/Utilities/AsyncCommand.cs
+++ b/Scripts/Core/Utilities/AsyncCommand.cs
@@ -14,7 +14,7 @@ namespace Core.Utilities
     {
         private readonly Func<Task> _execute;
         private readonly ReactiveProperty<bool> _isExecuting = new(false);
-        private readonly CompositeDisposable _disposables = new();
+        private readonly Core.Reactive.CompositeDisposable _disposables = new();
         private event EventHandler? _canExecuteChanged;
         private bool _disposed;
 

--- a/Scripts/Core/Utilities/AsyncCommand.cs
+++ b/Scripts/Core/Utilities/AsyncCommand.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using System.Reactive.Linq;
+using System.Windows.Input;
+using Core.Reactive;
+
+namespace Core.Utilities
+{
+    /// <summary>
+    /// 非同期処理向けのリアクティブコマンド
+    /// </summary>
+    public class AsyncCommand : ICommand, IDisposable
+    {
+        private readonly Func<Task> _execute;
+        private readonly ReactiveProperty<bool> _isExecuting = new(false);
+        private bool _disposed;
+
+        /// <summary>
+        /// 実行中状態を監視
+        /// </summary>
+        public IObservable<bool> IsExecuting => _isExecuting.ValueChanged;
+
+        public AsyncCommand(Func<Task> execute)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        }
+
+        public bool CanExecute(object parameter) => !_isExecuting.Value;
+
+        public event EventHandler? CanExecuteChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public async void Execute(object parameter)
+        {
+            if (!CanExecute(parameter)) return;
+            try
+            {
+                _isExecuting.Value = true;
+                await _execute();
+            }
+            finally
+            {
+                _isExecuting.Value = false;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _isExecuting.Dispose();
+            _disposed = true;
+        }
+    }
+}

--- a/Scripts/Core/Utilities/AsyncCommand.cs.uid
+++ b/Scripts/Core/Utilities/AsyncCommand.cs.uid
@@ -1,0 +1,1 @@
+uid://ecspd2qgrcqs

--- a/Scripts/Core/Utilities/CollectionChangeType.cs
+++ b/Scripts/Core/Utilities/CollectionChangeType.cs
@@ -1,0 +1,11 @@
+namespace Core.Utilities
+{
+    /// <summary>
+    /// コレクション変更種別
+    /// </summary>
+    public enum CollectionChangeType
+    {
+        Add,
+        Remove
+    }
+}

--- a/Scripts/Core/Utilities/CollectionChangeType.cs.uid
+++ b/Scripts/Core/Utilities/CollectionChangeType.cs.uid
@@ -1,0 +1,1 @@
+uid://bssouqobedter

--- a/Scripts/Core/Utilities/CollectionChangedEvent.cs
+++ b/Scripts/Core/Utilities/CollectionChangedEvent.cs
@@ -1,0 +1,17 @@
+namespace Core.Utilities
+{
+    /// <summary>
+    /// コレクション変更イベント
+    /// </summary>
+    public class CollectionChangedEvent<T>
+    {
+        public CollectionChangeType ChangeType { get; }
+        public T Item { get; }
+
+        public CollectionChangedEvent(CollectionChangeType changeType, T item)
+        {
+            ChangeType = changeType;
+            Item = item;
+        }
+    }
+}

--- a/Scripts/Core/Utilities/CollectionChangedEvent.cs.uid
+++ b/Scripts/Core/Utilities/CollectionChangedEvent.cs.uid
@@ -1,0 +1,1 @@
+uid://es26onmxgx8w

--- a/Scripts/Core/Utilities/EventAggregator.cs
+++ b/Scripts/Core/Utilities/EventAggregator.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+namespace Core.Utilities
+{
+    /// <summary>
+    /// シンプルなイベント集約クラス
+    /// </summary>
+    public class EventAggregator
+    {
+        private readonly Dictionary<Type, object> _handlers = new();
+        private readonly object _lock = new();
+
+        public void Publish<T>(T message) where T : class
+        {
+            lock (_lock)
+            {
+                if (_handlers.TryGetValue(typeof(T), out var list))
+                {
+                    foreach (var handler in (List<Action<T>>)list)
+                    {
+                        handler(message);
+                    }
+                }
+            }
+        }
+
+        public void Subscribe<T>(Action<T> handler) where T : class
+        {
+            lock (_lock)
+            {
+                var type = typeof(T);
+                if (!_handlers.TryGetValue(type, out var list))
+                {
+                    list = new List<Action<T>>();
+                    _handlers[type] = list;
+                }
+                ((List<Action<T>>)list).Add(handler);
+            }
+        }
+    }
+}

--- a/Scripts/Core/Utilities/EventAggregator.cs
+++ b/Scripts/Core/Utilities/EventAggregator.cs
@@ -13,14 +13,19 @@ namespace Core.Utilities
 
         public void Publish<T>(T message) where T : class
         {
+            List<Action<T>>? handlers_to_invoke = null;
             lock (_lock)
             {
                 if (_handlers.TryGetValue(typeof(T), out var list))
                 {
-                    foreach (var handler in (List<Action<T>>)list)
-                    {
-                        handler(message);
-                    }
+                    handlers_to_invoke = new List<Action<T>>((List<Action<T>>)list);
+                }
+            }
+            if (handlers_to_invoke != null)
+            {
+                foreach (var handler in handlers_to_invoke)
+                {
+                    handler(message);
                 }
             }
         }

--- a/Scripts/Core/Utilities/EventAggregator.cs.uid
+++ b/Scripts/Core/Utilities/EventAggregator.cs.uid
@@ -1,0 +1,1 @@
+uid://bh7jmdsy5n0qv

--- a/Scripts/Core/Utilities/LogEvent.cs
+++ b/Scripts/Core/Utilities/LogEvent.cs
@@ -1,0 +1,16 @@
+using System;
+using Core.Events;
+
+namespace Core.Utilities
+{
+    /// <summary>
+    /// ログイベント
+    /// </summary>
+    public class LogEvent : GameEvent
+    {
+        public LogLevel Level { get; set; }
+        public string Message { get; set; } = string.Empty;
+        public Exception? Exception { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/Scripts/Core/Utilities/LogEvent.cs.uid
+++ b/Scripts/Core/Utilities/LogEvent.cs.uid
@@ -1,0 +1,1 @@
+uid://cg8teeppygnhd

--- a/Scripts/Core/Utilities/LogFormatter.cs
+++ b/Scripts/Core/Utilities/LogFormatter.cs
@@ -1,0 +1,25 @@
+using System.Text;
+
+namespace Core.Utilities
+{
+    /// <summary>
+    /// ログイベントをフォーマットするユーティリティ
+    /// </summary>
+    public class LogFormatter
+    {
+        public string Format(LogEvent logEvent)
+        {
+            var sb = new StringBuilder();
+            sb.Append($"[{logEvent.Timestamp:yyyy-MM-dd HH:mm:ss}] ");
+            sb.Append($"{logEvent.Level}: {logEvent.Message}");
+
+            if (logEvent.Exception != null)
+            {
+                sb.AppendLine();
+                sb.Append($"Exception: {logEvent.Exception}");
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Scripts/Core/Utilities/LogFormatter.cs.uid
+++ b/Scripts/Core/Utilities/LogFormatter.cs.uid
@@ -1,0 +1,1 @@
+uid://bd5ceg411rd8q

--- a/Scripts/Core/Utilities/LogLevel.cs
+++ b/Scripts/Core/Utilities/LogLevel.cs
@@ -1,0 +1,13 @@
+namespace Core.Utilities
+{
+    /// <summary>
+    /// ログレベル
+    /// </summary>
+    public enum LogLevel
+    {
+        Debug,
+        Info,
+        Warning,
+        Error
+    }
+}

--- a/Scripts/Core/Utilities/LogLevel.cs.uid
+++ b/Scripts/Core/Utilities/LogLevel.cs.uid
@@ -1,0 +1,1 @@
+uid://dbcakxnxmodbi

--- a/Scripts/Core/Utilities/Logger.cs
+++ b/Scripts/Core/Utilities/Logger.cs
@@ -1,0 +1,35 @@
+using System;
+using Core.Events;
+
+namespace Core.Utilities
+{
+    /// <summary>
+    /// イベントバスへログを送信するロガー
+    /// </summary>
+    public class Logger
+    {
+        private readonly IGameEventBus _eventBus;
+        private readonly LogLevel _minimumLevel;
+
+        public Logger(IGameEventBus eventBus, LogLevel minimumLevel = LogLevel.Info)
+        {
+            _eventBus = eventBus;
+            _minimumLevel = minimumLevel;
+        }
+
+        public void Log(LogLevel level, string message, Exception? ex = null)
+        {
+            if (level < _minimumLevel) return;
+
+            var logEvent = new LogEvent
+            {
+                Level = level,
+                Message = message,
+                Exception = ex,
+                Timestamp = DateTime.UtcNow
+            };
+
+            _eventBus.Publish(logEvent);
+        }
+    }
+}

--- a/Scripts/Core/Utilities/Logger.cs.uid
+++ b/Scripts/Core/Utilities/Logger.cs.uid
@@ -1,0 +1,1 @@
+uid://dwaqswx8buf3x

--- a/Scripts/Core/Utilities/ReactiveCollection.cs
+++ b/Scripts/Core/Utilities/ReactiveCollection.cs
@@ -25,7 +25,9 @@ namespace Core.Utilities
             get => _items[index];
             set
             {
+                var old = _items[index];
                 _items[index] = value;
+                _changedSubject.OnNext(new CollectionChangedEvent<T>(CollectionChangeType.Remove, old));
                 _changedSubject.OnNext(new CollectionChangedEvent<T>(CollectionChangeType.Add, value));
             }
         }

--- a/Scripts/Core/Utilities/ReactiveCollection.cs
+++ b/Scripts/Core/Utilities/ReactiveCollection.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reactive.Subjects;
+using System.Reactive.Linq;
+
+namespace Core.Utilities
+{
+    /// <summary>
+    /// 変更通知付きコレクション
+    /// </summary>
+    public class ReactiveCollection<T> : IList<T>, IDisposable
+    {
+        private readonly List<T> _items = new();
+        private readonly Subject<CollectionChangedEvent<T>> _changedSubject = new();
+        private bool _disposed;
+
+        /// <summary>
+        /// 変更通知ストリーム
+        /// </summary>
+        public IObservable<CollectionChangedEvent<T>> Changed => _changedSubject.AsObservable();
+
+        public T this[int index]
+        {
+            get => _items[index];
+            set
+            {
+                _items[index] = value;
+                _changedSubject.OnNext(new CollectionChangedEvent<T>(CollectionChangeType.Add, value));
+            }
+        }
+
+        public int Count => _items.Count;
+        public bool IsReadOnly => false;
+
+        public void Add(T item)
+        {
+            _items.Add(item);
+            _changedSubject.OnNext(new CollectionChangedEvent<T>(CollectionChangeType.Add, item));
+        }
+
+        public void Clear()
+        {
+            foreach (var item in _items)
+            {
+                _changedSubject.OnNext(new CollectionChangedEvent<T>(CollectionChangeType.Remove, item));
+            }
+            _items.Clear();
+        }
+
+        public bool Contains(T item) => _items.Contains(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+
+        public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public int IndexOf(T item) => _items.IndexOf(item);
+
+        public void Insert(int index, T item)
+        {
+            _items.Insert(index, item);
+            _changedSubject.OnNext(new CollectionChangedEvent<T>(CollectionChangeType.Add, item));
+        }
+
+        public bool Remove(T item)
+        {
+            if (_items.Remove(item))
+            {
+                _changedSubject.OnNext(new CollectionChangedEvent<T>(CollectionChangeType.Remove, item));
+                return true;
+            }
+            return false;
+        }
+
+        public void RemoveAt(int index)
+        {
+            var item = _items[index];
+            _items.RemoveAt(index);
+            _changedSubject.OnNext(new CollectionChangedEvent<T>(CollectionChangeType.Remove, item));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _changedSubject.Dispose();
+            _disposed = true;
+        }
+    }
+}

--- a/Scripts/Core/Utilities/ReactiveCollection.cs.uid
+++ b/Scripts/Core/Utilities/ReactiveCollection.cs.uid
@@ -1,0 +1,1 @@
+uid://ti7k6s36xnbd

--- a/Scripts/Core/Utilities/ReactiveCommand.cs
+++ b/Scripts/Core/Utilities/ReactiveCommand.cs
@@ -14,6 +14,8 @@ namespace Core.Utilities
     {
         private readonly Subject<Unit> _executeSubject = new();
         private readonly ReactiveProperty<bool> _canExecute = new(true);
+        private readonly CompositeDisposable _disposables = new();
+        private event EventHandler? _canExecuteChanged;
         private bool _disposed;
 
         /// <summary>
@@ -26,12 +28,24 @@ namespace Core.Utilities
         /// </summary>
         public IObservable<bool> CanExecuteObservable => _canExecute.ValueChanged;
 
+        public ReactiveCommand()
+        {
+            _canExecute.ValueChanged
+                .Subscribe(_ => _canExecuteChanged?.Invoke(this, EventArgs.Empty))
+                .AddTo(_disposables);
+        }
+
         public bool CanExecute(object parameter) => _canExecute.Value;
 
         public event EventHandler? CanExecuteChanged
         {
-            add { }
-            remove { }
+            add { _canExecuteChanged += value; }
+            remove { _canExecuteChanged -= value; }
+        }
+
+        public void SetCanExecute(bool value)
+        {
+            _canExecute.Value = value;
         }
 
         public void Execute(object parameter)
@@ -45,6 +59,7 @@ namespace Core.Utilities
         public void Dispose()
         {
             if (_disposed) return;
+            _disposables.Dispose();
             _executeSubject.Dispose();
             _canExecute.Dispose();
             _disposed = true;
@@ -58,6 +73,8 @@ namespace Core.Utilities
     {
         private readonly Subject<T> _executeSubject = new();
         private readonly ReactiveProperty<bool> _canExecute = new(true);
+        private readonly CompositeDisposable _disposables = new();
+        private event EventHandler? _canExecuteChanged;
         private bool _disposed;
 
         /// <summary>
@@ -70,12 +87,24 @@ namespace Core.Utilities
         /// </summary>
         public IObservable<bool> CanExecuteObservable => _canExecute.ValueChanged;
 
+        public ReactiveCommand()
+        {
+            _canExecute.ValueChanged
+                .Subscribe(_ => _canExecuteChanged?.Invoke(this, EventArgs.Empty))
+                .AddTo(_disposables);
+        }
+
         public bool CanExecute(object parameter) => _canExecute.Value;
 
         public event EventHandler? CanExecuteChanged
         {
-            add { }
-            remove { }
+            add { _canExecuteChanged += value; }
+            remove { _canExecuteChanged -= value; }
+        }
+
+        public void SetCanExecute(bool value)
+        {
+            _canExecute.Value = value;
         }
 
         public void Execute(object parameter)
@@ -88,6 +117,7 @@ namespace Core.Utilities
         public void Dispose()
         {
             if (_disposed) return;
+            _disposables.Dispose();
             _executeSubject.Dispose();
             _canExecute.Dispose();
             _disposed = true;

--- a/Scripts/Core/Utilities/ReactiveCommand.cs
+++ b/Scripts/Core/Utilities/ReactiveCommand.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Reactive;
+using System.Reactive.Subjects;
+using System.Reactive.Linq;
+using System.Windows.Input;
+using Core.Reactive;
+
+namespace Core.Utilities
+{
+    /// <summary>
+    /// 実行可能状態を持つリアクティブコマンド
+    /// </summary>
+    public class ReactiveCommand : ICommand, IDisposable
+    {
+        private readonly Subject<Unit> _executeSubject = new();
+        private readonly ReactiveProperty<bool> _canExecute = new(true);
+        private bool _disposed;
+
+        /// <summary>
+        /// 実行通知ストリーム
+        /// </summary>
+        public IObservable<Unit> ExecuteObservable => _executeSubject.AsObservable();
+
+        /// <summary>
+        /// 実行可否ストリーム
+        /// </summary>
+        public IObservable<bool> CanExecuteObservable => _canExecute.ValueChanged;
+
+        public bool CanExecute(object parameter) => _canExecute.Value;
+
+        public event EventHandler? CanExecuteChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public void Execute(object parameter)
+        {
+            if (CanExecute(parameter))
+            {
+                _executeSubject.OnNext(Unit.Default);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _executeSubject.Dispose();
+            _canExecute.Dispose();
+            _disposed = true;
+        }
+    }
+
+    /// <summary>
+    /// パラメーターを受け取るリアクティブコマンド
+    /// </summary>
+    public class ReactiveCommand<T> : ICommand, IDisposable
+    {
+        private readonly Subject<T> _executeSubject = new();
+        private readonly ReactiveProperty<bool> _canExecute = new(true);
+        private bool _disposed;
+
+        /// <summary>
+        /// 実行通知ストリーム
+        /// </summary>
+        public IObservable<T> ExecuteObservable => _executeSubject.AsObservable();
+
+        /// <summary>
+        /// 実行可否ストリーム
+        /// </summary>
+        public IObservable<bool> CanExecuteObservable => _canExecute.ValueChanged;
+
+        public bool CanExecute(object parameter) => _canExecute.Value;
+
+        public event EventHandler? CanExecuteChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public void Execute(object parameter)
+        {
+            if (!CanExecute(parameter)) return;
+            var value = parameter is T t ? t : default!;
+            _executeSubject.OnNext(value);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _executeSubject.Dispose();
+            _canExecute.Dispose();
+            _disposed = true;
+        }
+    }
+}

--- a/Scripts/Core/Utilities/ReactiveCommand.cs
+++ b/Scripts/Core/Utilities/ReactiveCommand.cs
@@ -14,7 +14,7 @@ namespace Core.Utilities
     {
         private readonly Subject<Unit> _executeSubject = new();
         private readonly ReactiveProperty<bool> _canExecute = new(true);
-        private readonly CompositeDisposable _disposables = new();
+        private readonly Core.Reactive.CompositeDisposable _disposables = new();
         private event EventHandler? _canExecuteChanged;
         private bool _disposed;
 
@@ -73,7 +73,7 @@ namespace Core.Utilities
     {
         private readonly Subject<T> _executeSubject = new();
         private readonly ReactiveProperty<bool> _canExecute = new(true);
-        private readonly CompositeDisposable _disposables = new();
+        private readonly Core.Reactive.CompositeDisposable _disposables = new();
         private event EventHandler? _canExecuteChanged;
         private bool _disposed;
 

--- a/Scripts/Core/Utilities/ReactiveCommand.cs
+++ b/Scripts/Core/Utilities/ReactiveCommand.cs
@@ -110,8 +110,18 @@ namespace Core.Utilities
         public void Execute(object parameter)
         {
             if (!CanExecute(parameter)) return;
-            var value = parameter is T t ? t : default!;
-            _executeSubject.OnNext(value);
+            if (parameter is T t)
+            {
+                _executeSubject.OnNext(t);
+            }
+            else if (parameter is null)
+            {
+                _executeSubject.OnNext(default!);
+            }
+            else
+            {
+                throw new ArgumentException($"Invalid parameter type. Expected {typeof(T)}, but got {parameter.GetType()}", nameof(parameter));
+            }
         }
 
         public void Dispose()

--- a/Scripts/Core/Utilities/ReactiveCommand.cs.uid
+++ b/Scripts/Core/Utilities/ReactiveCommand.cs.uid
@@ -1,0 +1,1 @@
+uid://p1ka5tbtx4yx

--- a/Scripts/Core/Utilities/TaskExtensions.cs
+++ b/Scripts/Core/Utilities/TaskExtensions.cs
@@ -30,18 +30,23 @@ namespace Core.Utilities
         /// </summary>
         public static async Task<T> WithRetry<T>(this Func<Task<T>> taskFactory, int maxRetries)
         {
+            Exception? last = null;
             for (int i = 0; i < maxRetries; i++)
             {
                 try
                 {
                     return await taskFactory();
                 }
-                catch (Exception) when (i < maxRetries - 1)
+                catch (Exception ex)
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, i)));
+                    last = ex;
+                    if (i < maxRetries - 1)
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, i)));
+                    }
                 }
             }
-            return await taskFactory();
+            throw last ?? new Exception("Unknown error");
         }
     }
 }

--- a/Scripts/Core/Utilities/TaskExtensions.cs
+++ b/Scripts/Core/Utilities/TaskExtensions.cs
@@ -30,7 +30,7 @@ namespace Core.Utilities
         /// </summary>
         public static async Task<T> WithRetry<T>(this Func<Task<T>> taskFactory, int maxRetries)
         {
-            Exception? last = null;
+            Exception? last_exception = null;
             for (int i = 0; i < maxRetries; i++)
             {
                 try
@@ -39,14 +39,14 @@ namespace Core.Utilities
                 }
                 catch (Exception ex)
                 {
-                    last = ex;
+                    last_exception = ex;
                     if (i < maxRetries - 1)
                     {
                         await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, i)));
                     }
                 }
             }
-            throw last ?? new Exception("Unknown error");
+            throw last_exception ?? new Exception("Unknown error");
         }
     }
 }

--- a/Scripts/Core/Utilities/TaskExtensions.cs
+++ b/Scripts/Core/Utilities/TaskExtensions.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Core.Utilities
+{
+    /// <summary>
+    /// Taskに関する拡張メソッド
+    /// </summary>
+    public static class TaskExtensions
+    {
+        /// <summary>
+        /// タイムアウト付きで実行
+        /// </summary>
+        public static async Task<T> WithTimeout<T>(this Task<T> task, TimeSpan timeout)
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            try
+            {
+                return await task.WaitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                throw new TimeoutException();
+            }
+        }
+
+        /// <summary>
+        /// リトライ付き実行
+        /// </summary>
+        public static async Task<T> WithRetry<T>(this Func<Task<T>> taskFactory, int maxRetries)
+        {
+            for (int i = 0; i < maxRetries; i++)
+            {
+                try
+                {
+                    return await taskFactory();
+                }
+                catch (Exception) when (i < maxRetries - 1)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, i)));
+                }
+            }
+            return await taskFactory();
+        }
+    }
+}

--- a/Scripts/Core/Utilities/TaskExtensions.cs.uid
+++ b/Scripts/Core/Utilities/TaskExtensions.cs.uid
@@ -1,0 +1,1 @@
+uid://bxgc43mjuul16

--- a/Scripts/Core/Utilities/ValidationResult.cs
+++ b/Scripts/Core/Utilities/ValidationResult.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Core.Utilities
+{
+    /// <summary>
+    /// 検証結果
+    /// </summary>
+    public class ValidationResult
+    {
+        public IReadOnlyList<string> Errors { get; }
+
+        public bool IsValid => Errors.Count == 0;
+
+        public ValidationResult(IReadOnlyList<string> errors)
+        {
+            Errors = errors;
+        }
+    }
+}

--- a/Scripts/Core/Utilities/ValidationResult.cs.uid
+++ b/Scripts/Core/Utilities/ValidationResult.cs.uid
@@ -1,0 +1,1 @@
+uid://dfkks6qktq44k

--- a/Scripts/Core/Utilities/ValidationRule.cs
+++ b/Scripts/Core/Utilities/ValidationRule.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Core.Utilities
+{
+    /// <summary>
+    /// 単一の検証ルール
+    /// </summary>
+    public class ValidationRule<T>
+    {
+        public Func<T, bool> Validate { get; }
+        public string ErrorMessage { get; }
+
+        public ValidationRule(Func<T, bool> validate, string errorMessage)
+        {
+            Validate = validate;
+            ErrorMessage = errorMessage;
+        }
+    }
+}

--- a/Scripts/Core/Utilities/ValidationRule.cs.uid
+++ b/Scripts/Core/Utilities/ValidationRule.cs.uid
@@ -1,0 +1,1 @@
+uid://bngmjnrc673

--- a/Scripts/Core/Utilities/Validator.cs
+++ b/Scripts/Core/Utilities/Validator.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace Core.Utilities
+{
+    /// <summary>
+    /// 検証ユーティリティ
+    /// </summary>
+    public class Validator<T>
+    {
+        private readonly List<ValidationRule<T>> _rules = new();
+
+        public void AddRule(ValidationRule<T> rule)
+        {
+            _rules.Add(rule);
+        }
+
+        public ValidationResult Validate(T value)
+        {
+            var errors = new List<string>();
+
+            foreach (var rule in _rules)
+            {
+                if (!rule.Validate(value))
+                {
+                    errors.Add(rule.ErrorMessage);
+                }
+            }
+
+            return new ValidationResult(errors);
+        }
+    }
+}

--- a/Scripts/Core/Utilities/Validator.cs.uid
+++ b/Scripts/Core/Utilities/Validator.cs.uid
@@ -1,0 +1,1 @@
+uid://cf2bbxdmrst24

--- a/Scripts/Core/Utilities/WeakEventManager.cs
+++ b/Scripts/Core/Utilities/WeakEventManager.cs
@@ -27,5 +27,31 @@ namespace Core.Utilities
                 list.RemoveAll(wr => !wr.IsAlive || wr.Target == handler);
             }
         }
+
+        /// <summary>
+        /// 登録されたハンドラを呼び出す
+        /// </summary>
+        public void RaiseEvent(string eventName, object sender, EventArgs args)
+        {
+            if (_handlers.TryGetValue(eventName, out var list))
+            {
+                var dead = new List<WeakReference>();
+                foreach (var wr in list)
+                {
+                    if (wr.IsAlive && wr.Target is EventHandler handler)
+                    {
+                        handler(sender, args);
+                    }
+                    else
+                    {
+                        dead.Add(wr);
+                    }
+                }
+                foreach (var d in dead)
+                {
+                    list.Remove(d);
+                }
+            }
+        }
     }
 }

--- a/Scripts/Core/Utilities/WeakEventManager.cs
+++ b/Scripts/Core/Utilities/WeakEventManager.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace Core.Utilities
+{
+    /// <summary>
+    /// 弱参照でイベントハンドラを管理するクラス
+    /// </summary>
+    public class WeakEventManager
+    {
+        private readonly Dictionary<string, List<WeakReference>> _handlers = new();
+
+        public void AddHandler(string eventName, EventHandler handler)
+        {
+            if (!_handlers.TryGetValue(eventName, out var list))
+            {
+                list = new List<WeakReference>();
+                _handlers[eventName] = list;
+            }
+            list.Add(new WeakReference(handler));
+        }
+
+        public void RemoveHandler(string eventName, EventHandler handler)
+        {
+            if (_handlers.TryGetValue(eventName, out var list))
+            {
+                list.RemoveAll(wr => !wr.IsAlive || wr.Target == handler);
+            }
+        }
+    }
+}

--- a/Scripts/Core/Utilities/WeakEventManager.cs.uid
+++ b/Scripts/Core/Utilities/WeakEventManager.cs.uid
@@ -1,0 +1,1 @@
+uid://bbrksitdifhkp

--- a/Scripts/Core/ViewModels/ViewModelBase.cs
+++ b/Scripts/Core/ViewModels/ViewModelBase.cs
@@ -24,12 +24,12 @@ namespace Core.ViewModels
         /// <summary>
         /// ビジー状態
         /// </summary>
-        protected ReactiveProperty<bool> IsBusy { get; } = new(false);
+        protected ReactiveProperty<bool> IsBusy { get; }
 
         /// <summary>
         /// ViewModelの状態
         /// </summary>
-        public ReactiveProperty<ViewModelState> State { get; } = new(ViewModelState.Initial);
+        public ReactiveProperty<ViewModelState> State { get; }
 
         /// <summary>
         /// コンストラクタ
@@ -37,6 +37,8 @@ namespace Core.ViewModels
         protected ViewModelBase(IGameEventBus eventBus)
         {
             EventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
+            IsBusy = new ReactiveProperty<bool>(false).AddTo(Disposables);
+            State = new ReactiveProperty<ViewModelState>(ViewModelState.Initial).AddTo(Disposables);
         }
 
         /// <summary>

--- a/Scripts/Core/ViewModels/ViewModelBase.cs
+++ b/Scripts/Core/ViewModels/ViewModelBase.cs
@@ -1,6 +1,8 @@
 using System;
 using Core.Events;
 using Core.Reactive;
+using Core.Utilities;
+using System.Threading.Tasks;
 
 namespace Core.ViewModels
 {
@@ -20,6 +22,16 @@ namespace Core.ViewModels
         protected readonly IGameEventBus EventBus;
 
         /// <summary>
+        /// ビジー状態
+        /// </summary>
+        protected ReactiveProperty<bool> IsBusy { get; } = new(false);
+
+        /// <summary>
+        /// ViewModelの状態
+        /// </summary>
+        public ReactiveProperty<ViewModelState> State { get; } = new(ViewModelState.Initial);
+
+        /// <summary>
         /// コンストラクタ
         /// </summary>
         protected ViewModelBase(IGameEventBus eventBus)
@@ -36,6 +48,15 @@ namespace Core.ViewModels
         }
 
         /// <summary>
+        /// IDisposable を登録
+        /// </summary>
+        protected void AddDisposable(IDisposable disposable)
+        {
+            if (disposable == null) return;
+            Disposables.Add(disposable);
+        }
+
+        /// <summary>
         /// イベントの購読
         /// </summary>
         protected IDisposable SubscribeToEvent<T>(Action<T> onNext) where T : GameEvent
@@ -43,6 +64,38 @@ namespace Core.ViewModels
             var subscription = EventBus.GetEventStream<T>().Subscribe(onNext);
             Disposables.Add(subscription);
             return subscription;
+        }
+
+        /// <summary>
+        /// ReactiveCommand を生成
+        /// </summary>
+        protected ReactiveCommand CreateCommand()
+        {
+            return new ReactiveCommand().AddTo(Disposables);
+        }
+
+        /// <summary>
+        /// 型付き ReactiveCommand を生成
+        /// </summary>
+        protected ReactiveCommand<T> CreateCommand<T>()
+        {
+            return new ReactiveCommand<T>().AddTo(Disposables);
+        }
+
+        /// <summary>
+        /// 非同期処理を実行
+        /// </summary>
+        protected async Task ExecuteAsync(Func<Task> action)
+        {
+            try
+            {
+                IsBusy.Value = true;
+                await action();
+            }
+            finally
+            {
+                IsBusy.Value = false;
+            }
         }
 
         /// <summary>
@@ -59,6 +112,38 @@ namespace Core.ViewModels
         protected void SetValue<T>(IReactiveProperty<T> property, T value)
         {
             property.Value = value;
+        }
+
+        /// <summary>
+        /// アクティブ化処理
+        /// </summary>
+        public virtual void Activate()
+        {
+            OnActivate();
+        }
+
+        /// <summary>
+        /// 非アクティブ化処理
+        /// </summary>
+        public virtual void Deactivate()
+        {
+            OnDeactivate();
+        }
+
+        /// <summary>
+        /// アクティブ化時の処理
+        /// </summary>
+        protected virtual void OnActivate()
+        {
+            State.Value = ViewModelState.Active;
+        }
+
+        /// <summary>
+        /// 非アクティブ化時の処理
+        /// </summary>
+        protected virtual void OnDeactivate()
+        {
+            State.Value = ViewModelState.Inactive;
         }
     }
 }

--- a/Scripts/Core/ViewModels/ViewModelState.cs
+++ b/Scripts/Core/ViewModels/ViewModelState.cs
@@ -1,0 +1,12 @@
+namespace Core.ViewModels
+{
+    /// <summary>
+    /// ViewModelの状態
+    /// </summary>
+    public enum ViewModelState
+    {
+        Initial,
+        Active,
+        Inactive
+    }
+}

--- a/Scripts/Core/ViewModels/ViewModelState.cs.uid
+++ b/Scripts/Core/ViewModels/ViewModelState.cs.uid
@@ -1,0 +1,1 @@
+uid://btab6cbb8mewm

--- a/Tests/Core/CommandTests.cs
+++ b/Tests/Core/CommandTests.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using System.Threading.Tasks;
+using Core.Utilities;
+
+namespace Tests.Core
+{
+    public class CommandTests
+    {
+        [Test]
+        public void ReactiveCommand_Execute_Notifies()
+        {
+            var cmd = new ReactiveCommand();
+            bool executed = false;
+            using (cmd.ExecuteObservable.Subscribe(_ => executed = true))
+            {
+                cmd.Execute(null);
+            }
+            Assert.IsTrue(executed);
+        }
+
+        [Test]
+        public void ReactiveCommandT_Execute_PassesValue()
+        {
+            var cmd = new ReactiveCommand<int>();
+            int received = 0;
+            using (cmd.ExecuteObservable.Subscribe(v => received = v))
+            {
+                cmd.Execute(42);
+            }
+            Assert.AreEqual(42, received);
+        }
+
+        [Test]
+        public async Task AsyncCommand_Execute_UpdatesState()
+        {
+            bool run = false;
+            var cmd = new AsyncCommand(async () =>
+            {
+                await Task.Delay(10);
+                run = true;
+            });
+            cmd.Execute(null);
+            await Task.Delay(20);
+            Assert.IsTrue(run);
+        }
+    }
+}

--- a/Tests/Core/CommandTests.cs
+++ b/Tests/Core/CommandTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using System;
 using System.Threading.Tasks;
 using Core.Utilities;
 
@@ -42,6 +43,16 @@ namespace Tests.Core
             cmd.Execute(null);
             await Task.Delay(20);
             Assert.IsTrue(run);
+        }
+
+        [Test]
+        public void ReactiveCommand_CanExecuteChanged_Raises()
+        {
+            var cmd = new ReactiveCommand();
+            bool raised = false;
+            cmd.CanExecuteChanged += (_, _) => raised = true;
+            cmd.SetCanExecute(false);
+            Assert.IsTrue(raised);
         }
     }
 }

--- a/Tests/Core/CommandTests.cs.uid
+++ b/Tests/Core/CommandTests.cs.uid
@@ -1,0 +1,1 @@
+uid://b54fne45vh48n

--- a/Tests/Core/ReactiveCollectionTests.cs
+++ b/Tests/Core/ReactiveCollectionTests.cs
@@ -1,0 +1,34 @@
+using NUnit.Framework;
+using Core.Utilities;
+using System.Linq;
+
+namespace Tests.Core
+{
+    public class ReactiveCollectionTests
+    {
+        [Test]
+        public void Add_RaisesChangeEvent()
+        {
+            var col = new ReactiveCollection<int>();
+            int notified = 0;
+            using (col.Changed.Subscribe(e => notified = e.Item))
+            {
+                col.Add(1);
+            }
+            Assert.AreEqual(1, notified);
+        }
+
+        [Test]
+        public void Remove_RaisesChangeEvent()
+        {
+            var col = new ReactiveCollection<string>();
+            col.Add("a");
+            string notified = string.Empty;
+            using (col.Changed.Subscribe(e => notified = e.Item))
+            {
+                col.Remove("a");
+            }
+            Assert.AreEqual("a", notified);
+        }
+    }
+}

--- a/Tests/Core/ReactiveCollectionTests.cs
+++ b/Tests/Core/ReactiveCollectionTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using Core.Utilities;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace Tests.Core
 {
@@ -29,6 +30,24 @@ namespace Tests.Core
                 col.Remove("a");
             }
             Assert.AreEqual("a", notified);
+        }
+
+        [Test]
+        public void Indexer_Set_ReplacesItemWithNotifications()
+        {
+            var col = new ReactiveCollection<int>();
+            col.Add(1);
+            col.Add(2);
+            var events = new List<CollectionChangedEvent<int>>();
+            using (col.Changed.Subscribe(e => events.Add(e)))
+            {
+                col[0] = 5;
+            }
+            Assert.AreEqual(2, events.Count);
+            Assert.AreEqual(CollectionChangeType.Remove, events[0].ChangeType);
+            Assert.AreEqual(1, events[0].Item);
+            Assert.AreEqual(CollectionChangeType.Add, events[1].ChangeType);
+            Assert.AreEqual(5, events[1].Item);
         }
     }
 }

--- a/Tests/Core/ReactiveCollectionTests.cs.uid
+++ b/Tests/Core/ReactiveCollectionTests.cs.uid
@@ -1,0 +1,1 @@
+uid://ct8faasaej2um

--- a/Tests/Core/ReactivePropertyAdvancedTests.cs
+++ b/Tests/Core/ReactivePropertyAdvancedTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using Core.Reactive;
+
+namespace Tests.Core
+{
+    public class ReactivePropertyAdvancedTests
+    {
+        [Test]
+        public void ValueChanged_Observable_Notifies()
+        {
+            var prop = new ReactiveProperty<int>(0);
+            int received = -1;
+            using (prop.ValueChanged.Subscribe(v => received = v))
+            {
+                prop.Value = 5;
+            }
+            Assert.AreEqual(5, received);
+        }
+
+        [Test]
+        public void SetValidator_PreventsInvalidValue()
+        {
+            var prop = new ReactiveProperty<int>(0);
+            prop.SetValidator(v => v >= 0);
+            prop.Value = -1;
+            Assert.AreEqual(0, prop.Value);
+        }
+
+        [Test]
+        public void BeginUpdate_SuppressesNotifications()
+        {
+            var prop = new ReactiveProperty<int>(0);
+            var list = new List<int>();
+            using (prop.Subscribe(v => list.Add(v)))
+            {
+                prop.BeginUpdate();
+                prop.Value = 1;
+                prop.Value = 2;
+                prop.EndUpdate();
+            }
+            CollectionAssert.AreEqual(new[] { 2 }, list);
+        }
+    }
+}

--- a/Tests/Core/ReactivePropertyAdvancedTests.cs
+++ b/Tests/Core/ReactivePropertyAdvancedTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using Core.Reactive;
 
@@ -23,7 +24,7 @@ namespace Tests.Core
         {
             var prop = new ReactiveProperty<int>(0);
             prop.SetValidator(v => v >= 0);
-            prop.Value = -1;
+            Assert.Throws<ArgumentException>(() => prop.Value = -1);
             Assert.AreEqual(0, prop.Value);
         }
 

--- a/Tests/Core/ReactivePropertyAdvancedTests.cs.uid
+++ b/Tests/Core/ReactivePropertyAdvancedTests.cs.uid
@@ -1,0 +1,1 @@
+uid://6gwm4mpicftu

--- a/Tests/Core/ViewModelBaseTests.cs
+++ b/Tests/Core/ViewModelBaseTests.cs
@@ -81,5 +81,16 @@ namespace Tests.Core
 
             Assert.AreEqual("new", property.Value);
         }
+
+        [Test]
+        public void Activate_ChangesState()
+        {
+            var bus = new GameEventBus();
+            var vm = new TestViewModel(bus);
+            vm.Activate();
+            Assert.AreEqual(ViewModelState.Active, vm.State.Value);
+            vm.Deactivate();
+            Assert.AreEqual(ViewModelState.Inactive, vm.State.Value);
+        }
     }
 }

--- a/Tests/Core/WeakEventManagerTests.cs
+++ b/Tests/Core/WeakEventManagerTests.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using Core.Utilities;
+using System;
+
+namespace Tests.Core
+{
+    public class WeakEventManagerTests
+    {
+        [Test]
+        public void RaiseEvent_InvokesHandlers()
+        {
+            var mgr = new WeakEventManager();
+            int called = 0;
+            EventHandler handler = (_, _) => called++;
+            mgr.AddHandler("test", handler);
+            mgr.RaiseEvent("test", this, EventArgs.Empty);
+            Assert.AreEqual(1, called);
+            mgr.RemoveHandler("test", handler);
+            mgr.RaiseEvent("test", this, EventArgs.Empty);
+            Assert.AreEqual(1, called);
+        }
+    }
+}

--- a/Tests/Core/WeakEventManagerTests.cs
+++ b/Tests/Core/WeakEventManagerTests.cs
@@ -7,7 +7,7 @@ namespace Tests.Core
     public class WeakEventManagerTests
     {
         [Test]
-        public void RaiseEvent_InvokesHandlers()
+        public void AddRaiseRemove_Works()
         {
             var mgr = new WeakEventManager();
             int called = 0;
@@ -18,6 +18,32 @@ namespace Tests.Core
             mgr.RemoveHandler("test", handler);
             mgr.RaiseEvent("test", this, EventArgs.Empty);
             Assert.AreEqual(1, called);
+        }
+
+        private class Dummy
+        {
+            private readonly Action _onCall;
+            public Dummy(Action onCall) => _onCall = onCall;
+            public void Handler(object? s, EventArgs e) => _onCall();
+        }
+
+        [Test]
+        public void DeadHandlers_AreCleanedUp()
+        {
+            var mgr = new WeakEventManager();
+            int called = 0;
+            EventHandler handler = (_, _) => called++;
+            mgr.AddHandler("dead", handler);
+
+            var field = typeof(WeakEventManager).GetField("_handlers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var dict = (System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<WeakReference>>)field.GetValue(mgr)!;
+            dict["dead"].Add(new WeakReference(null));
+            Assert.AreEqual(2, dict["dead"].Count);
+
+            handler = null;
+            mgr.RaiseEvent("dead", this, EventArgs.Empty);
+            Assert.AreEqual(1, called);
+            Assert.AreEqual(1, dict["dead"].Count);
         }
     }
 }

--- a/Tests/Core/WeakEventManagerTests.cs.uid
+++ b/Tests/Core/WeakEventManagerTests.cs.uid
@@ -1,0 +1,1 @@
+uid://dffb6y8w5a0vp


### PR DESCRIPTION
## 変更点
- `*.uid` を `.gitignore` から削除
- 型付き `ReactiveCommand<T>` を実装
- `ViewModelBase` で汎用コマンド生成 `CreateCommand<T>` を追加
- 新しいコマンドを検証するテストを追加

## テスト
- `bash setup_godot_cli.sh`
- `dotnet test Tests/Core/CoreTests.csproj -v minimal`
- `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json` *(何も実行されずエラー 7)*


------
https://chatgpt.com/codex/tasks/task_e_6846f421622483239b3c63e07472bd61