### PR TITLE
Fix missing Update and Dispose methods

### DIFF
--- a/Scripts/Core/Events/GameEventBus.cs
+++ b/Scripts/Core/Events/GameEventBus.cs
@@ -8,7 +8,7 @@ namespace Core.Events
     /// <summary>
     /// ゲームイベントを発行・購読するバス
     /// </summary>
-    public class GameEventBus : IGameEventBus
+    public class GameEventBus : IGameEventBus, IDisposable
     {
         private readonly ConcurrentDictionary<Type, ISubject<GameEvent>> _subjects = new();
 
@@ -32,6 +32,19 @@ namespace Core.Events
         private ISubject<GameEvent> GetOrCreateSubject(Type type)
         {
             return _subjects.GetOrAdd(type, _ => Subject.Synchronize(new Subject<GameEvent>()));
+        }
+
+        /// <summary>
+        /// バスが保持するリソースを解放する
+        /// </summary>
+        public void Dispose()
+        {
+            foreach (var subject in _subjects.Values)
+            {
+                subject.OnCompleted();
+                subject.Dispose();
+            }
+            _subjects.Clear();
         }
     }
 }

--- a/Scripts/Core/Events/GameEventBus.cs
+++ b/Scripts/Core/Events/GameEventBus.cs
@@ -11,6 +11,7 @@ namespace Core.Events
     public class GameEventBus : IGameEventBus, IDisposable
     {
         private readonly ConcurrentDictionary<Type, ISubject<GameEvent>> _subjects = new();
+        private bool _disposed;
 
         /// <summary>
         /// イベントを発行
@@ -39,12 +40,18 @@ namespace Core.Events
         /// </summary>
         public void Dispose()
         {
+            if (_disposed)
+            {
+                return;
+            }
+
             foreach (var subject in _subjects.Values)
             {
                 subject.OnCompleted();
                 subject.Dispose();
             }
             _subjects.Clear();
+            _disposed = true;
         }
     }
 }

--- a/Scripts/Systems/Player/Animation/PlayerAnimationViewModel.cs
+++ b/Scripts/Systems/Player/Animation/PlayerAnimationViewModel.cs
@@ -44,6 +44,14 @@ namespace Systems.Player.Animation
             UpdateAnimationState();
         }
 
+        /// <summary>
+        /// 毎フレーム更新処理
+        /// </summary>
+        public void Update()
+        {
+            UpdateAnimation();
+        }
+
         public void HandleAnimation(string animationName)
         {
             _model.PlayAnimation(animationName);

--- a/Scripts/Systems/Player/Combat/PlayerCombatViewModel.cs
+++ b/Scripts/Systems/Player/Combat/PlayerCombatViewModel.cs
@@ -46,6 +46,14 @@ namespace Systems.Player.Combat
             UpdateCombatState();
         }
 
+        /// <summary>
+        /// 毎フレーム更新処理
+        /// </summary>
+        public void Update()
+        {
+            UpdateCombat();
+        }
+
         public void Attack(string actionName)
         {
             _model.Attack(actionName);

--- a/Scripts/Systems/Player/Progression/PlayerProgressionViewModel.cs
+++ b/Scripts/Systems/Player/Progression/PlayerProgressionViewModel.cs
@@ -67,6 +67,14 @@ namespace Systems.Player.Progression
             UpdateProgressionState();
         }
 
+        /// <summary>
+        /// 毎フレーム更新処理
+        /// </summary>
+        public void Update()
+        {
+            UpdateProgression();
+        }
+
         private void UpdateProgressionState()
         {
             _level.Value = _model.CurrentLevel;


### PR DESCRIPTION
## Summary
- view models now have `Update()` wrapper methods
- event bus can now dispose its subjects

## Testing
- `./setup_godot_cli.sh`
- `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68494d9242b08323b5c2a3e29f5643f4