### PR TITLE
Fix compiler warnings

### DIFF
--- a/Scripts/Core/Reactive/ReactiveProperty.cs
+++ b/Scripts/Core/Reactive/ReactiveProperty.cs
@@ -52,7 +52,7 @@ namespace Core.Reactive
         /// <summary>
         /// 初期値を設定してプロパティを生成
         /// </summary>
-        public ReactiveProperty(T initialValue = default)
+        public ReactiveProperty(T initialValue = default!)
         {
             _value = initialValue;
             // Subject.Synchronize で購読処理を同期化し、スレッド安全性を確保

--- a/Scripts/Core/Utilities/AsyncCommand.cs
+++ b/Scripts/Core/Utilities/AsyncCommand.cs
@@ -31,7 +31,7 @@ namespace Core.Utilities
                 .AddTo(_disposables);
         }
 
-        public bool CanExecute(object parameter) => !_isExecuting.Value;
+        public bool CanExecute(object? parameter) => !_isExecuting.Value;
 
         public event EventHandler? CanExecuteChanged
         {
@@ -39,7 +39,7 @@ namespace Core.Utilities
             remove { _canExecuteChanged -= value; }
         }
 
-        public async void Execute(object parameter)
+        public async void Execute(object? parameter)
         {
             if (!CanExecute(parameter)) return;
             try

--- a/Scripts/Core/Utilities/LogEvent.cs
+++ b/Scripts/Core/Utilities/LogEvent.cs
@@ -11,6 +11,6 @@ namespace Core.Utilities
         public LogLevel Level { get; set; }
         public string Message { get; set; } = string.Empty;
         public Exception? Exception { get; set; }
-        public DateTime Timestamp { get; set; }
+        public new DateTime Timestamp { get; set; }
     }
 }

--- a/Scripts/Core/Utilities/ReactiveCommand.cs
+++ b/Scripts/Core/Utilities/ReactiveCommand.cs
@@ -35,7 +35,7 @@ namespace Core.Utilities
                 .AddTo(_disposables);
         }
 
-        public bool CanExecute(object parameter) => _canExecute.Value;
+        public bool CanExecute(object? parameter) => _canExecute.Value;
 
         public event EventHandler? CanExecuteChanged
         {
@@ -48,7 +48,7 @@ namespace Core.Utilities
             _canExecute.Value = value;
         }
 
-        public void Execute(object parameter)
+        public void Execute(object? parameter)
         {
             if (CanExecute(parameter))
             {
@@ -94,7 +94,7 @@ namespace Core.Utilities
                 .AddTo(_disposables);
         }
 
-        public bool CanExecute(object parameter) => _canExecute.Value;
+        public bool CanExecute(object? parameter) => _canExecute.Value;
 
         public event EventHandler? CanExecuteChanged
         {
@@ -107,7 +107,7 @@ namespace Core.Utilities
             _canExecute.Value = value;
         }
 
-        public void Execute(object parameter)
+        public void Execute(object? parameter)
         {
             if (!CanExecute(parameter)) return;
             if (parameter is T t)

--- a/Scripts/Core/Utilities/WeakEventManager.cs
+++ b/Scripts/Core/Utilities/WeakEventManager.cs
@@ -24,7 +24,15 @@ namespace Core.Utilities
         {
             if (_handlers.TryGetValue(eventName, out var list))
             {
-                list.RemoveAll(wr => !wr.IsAlive || wr.Target == handler);
+                list.RemoveAll(wr =>
+                {
+                    if (!wr.IsAlive) return true;
+                    if (wr.Target is EventHandler h)
+                    {
+                        return h == handler;
+                    }
+                    return false;
+                });
             }
         }
 

--- a/Scripts/Core/Utilities/WeakEventManager.cs
+++ b/Scripts/Core/Utilities/WeakEventManager.cs
@@ -24,15 +24,8 @@ namespace Core.Utilities
         {
             if (_handlers.TryGetValue(eventName, out var list))
             {
-                list.RemoveAll(wr =>
-                {
-                    if (!wr.IsAlive) return true;
-                    if (wr.Target is EventHandler h)
-                    {
-                        return h == handler;
-                    }
-                    return false;
-                });
+                // 参照が失効しているか、同じハンドラであれば削除
+                list.RemoveAll(wr => !wr.IsAlive || (wr.Target is EventHandler h && h == handler));
             }
         }
 


### PR DESCRIPTION
## Summary
- NULL許容修飾子の不一致を修正
- ReactiveProperty の初期値設定を明示
- 重複プロパティを `new` で隠蔽
- WeakEventManager のデリゲート比較を修正

## Testing
- `dotnet build NewGameProject.csproj -c Debug`
- `godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6854acd460b88323976a01997e0656f3