### PR TITLE
Add basic frame and input buffering systems

### DIFF
--- a/Scripts/Core/Events/GameEventBus.cs
+++ b/Scripts/Core/Events/GameEventBus.cs
@@ -39,10 +39,10 @@ namespace Core.Events
 		private volatile bool _disposed;
 		private readonly int _maxEventQueueSize = 1000; // イベントキューサイズの上限
 
-		/// <summary>
-		/// プライベートコンストラクタ
-		/// </summary>
-		private GameEventBus() { _disposed = false; }
+                /// <summary>
+                /// インスタンスを生成するコンストラクタ
+                /// </summary>
+                public GameEventBus() { _disposed = false; }
 
 		/// <summary>
 		/// イベントを発行
@@ -117,11 +117,11 @@ namespace Core.Events
 		/// <summary>
 		/// バスが保持するリソースを解放する（テスト用）
 		/// </summary>
-		internal void Dispose()
-		{
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
+                public void Dispose()
+                {
+                        Dispose(true);
+                        GC.SuppressFinalize(this);
+                }
 
 		/// <summary>
 		/// IDisposableの明示的実装（アプリ本体からは何もしない）

--- a/Scripts/Systems/Player/Combat/ActionExecutionManager.cs
+++ b/Scripts/Systems/Player/Combat/ActionExecutionManager.cs
@@ -1,0 +1,46 @@
+using Core.Events;
+using Systems.Player.Events;
+using Systems.Player.State;
+
+namespace Systems.Player.Combat
+{
+    /// <summary>
+    /// アクション実行を管理するクラス
+    /// </summary>
+    public class ActionExecutionManager
+    {
+        private readonly FrameStateManager _frame_manager;
+        private readonly CancelRuleManager _cancel_manager;
+        private readonly IGameEventBus _event_bus;
+
+        public ActionExecutionManager(FrameStateManager frameManager, CancelRuleManager cancelManager, IGameEventBus bus)
+        {
+            _frame_manager = frameManager;
+            _cancel_manager = cancelManager;
+            _event_bus = bus;
+        }
+
+        /// <summary>
+        /// アクションを実行する
+        /// </summary>
+        public void ExecuteAction(ActionFrameData data)
+        {
+            // FrameStateManager がイベントを送信するためここでは実行のみ行う
+            _frame_manager.StartAction(data);
+        }
+
+        /// <summary>
+        /// 現在のアクションをキャンセルして新しいアクションを実行
+        /// </summary>
+        public bool TryCancel(ActionFrameData newAction)
+        {
+            if (_cancel_manager.CanCancel(newAction.ActionName))
+            {
+                _event_bus.Publish(new ActionCanceledEvent(newAction.ActionName));
+                _frame_manager.StartAction(newAction);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Scripts/Systems/Player/Combat/ActionExecutionManager.cs
+++ b/Scripts/Systems/Player/Combat/ActionExecutionManager.cs
@@ -34,9 +34,10 @@ namespace Systems.Player.Combat
         /// </summary>
         public bool TryCancel(ActionFrameData newAction)
         {
-            if (_cancel_manager.CanCancel(newAction.ActionName))
+            var current = _frame_manager.CurrentAction;
+            if (current != null && _cancel_manager.CanCancel(newAction.ActionName))
             {
-                _event_bus.Publish(new ActionCanceledEvent(newAction.ActionName));
+                _event_bus.Publish(new ActionCanceledEvent(current.ActionName));
                 _frame_manager.StartAction(newAction);
                 return true;
             }

--- a/Scripts/Systems/Player/Combat/CancelRule.cs
+++ b/Scripts/Systems/Player/Combat/CancelRule.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Systems.Player.Combat
+{
+    /// <summary>
+    /// キャンセルルールを定義するクラス
+    /// </summary>
+    public class CancelRule
+    {
+        public string FromAction { get; }
+        public int StartFrame { get; }
+        public int EndFrame { get; }
+        public List<string> AllowedActions { get; }
+        public int Priority { get; }
+
+        public CancelRule(string fromAction, int startFrame, int endFrame, IEnumerable<string> allowedActions, int priority)
+        {
+            FromAction = fromAction;
+            StartFrame = startFrame;
+            EndFrame = endFrame;
+            AllowedActions = allowedActions.ToList();
+            Priority = priority;
+        }
+
+        /// <summary>
+        /// キャンセル可能か判定する
+        /// </summary>
+        public bool CanCancel(string toAction, int frameOffset)
+        {
+            return frameOffset >= StartFrame && frameOffset <= EndFrame && AllowedActions.Contains(toAction);
+        }
+    }
+}

--- a/Scripts/Systems/Player/Combat/CancelRuleManager.cs
+++ b/Scripts/Systems/Player/Combat/CancelRuleManager.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Linq;
+using Systems.Player.State;
+
+namespace Systems.Player.Combat
+{
+    /// <summary>
+    /// キャンセルルールを管理するクラス
+    /// </summary>
+    public class CancelRuleManager
+    {
+        private readonly List<CancelRule> _rules = new();
+        private readonly FrameStateManager _frame_manager;
+
+        public CancelRuleManager(FrameStateManager frameManager)
+        {
+            _frame_manager = frameManager;
+        }
+
+        /// <summary>
+        /// ルールを初期化する
+        /// </summary>
+        public void InitializeDefaultRules()
+        {
+            _rules.Add(new CancelRule(
+                "Attack_L1",
+                14,
+                20,
+                new[] { "Dodge", "Attack_L2" },
+                1));
+            _rules.Add(new CancelRule(
+                "Dodge",
+                18,
+                26,
+                new[] { "Attack_L1", "ChargeAttack" },
+                1));
+        }
+
+        /// <summary>
+        /// キャンセル可能か判定する
+        /// </summary>
+        public bool CanCancel(string toAction)
+        {
+            if (_frame_manager.CurrentAction == null) return false;
+            var fromAction = _frame_manager.CurrentAction.ActionName;
+            var offset = _frame_manager.CurrentFrame - _frame_manager.CurrentAction.StartFrame;
+            return _rules
+                .Where(r => r.FromAction == fromAction)
+                .Where(r => r.CanCancel(toAction, offset))
+                .OrderByDescending(r => r.Priority)
+                .Any();
+        }
+    }
+}

--- a/Scripts/Systems/Player/Events/FrameEvents.cs
+++ b/Scripts/Systems/Player/Events/FrameEvents.cs
@@ -1,0 +1,52 @@
+using Core.Events;
+
+namespace Systems.Player.Events
+{
+    /// <summary>
+    /// フレーム進行イベント
+    /// </summary>
+    public class FrameAdvancedEvent : GameEvent
+    {
+        public int Frame { get; }
+        public FrameAdvancedEvent(int frame)
+        {
+            Frame = frame;
+        }
+    }
+
+    /// <summary>
+    /// アクション開始イベント
+    /// </summary>
+    public class ActionStartedEvent : GameEvent
+    {
+        public string ActionName { get; }
+        public ActionStartedEvent(string actionName)
+        {
+            ActionName = actionName;
+        }
+    }
+
+    /// <summary>
+    /// アクション終了イベント
+    /// </summary>
+    public class ActionEndedEvent : GameEvent
+    {
+        public string ActionName { get; }
+        public ActionEndedEvent(string actionName)
+        {
+            ActionName = actionName;
+        }
+    }
+
+    /// <summary>
+    /// アクションキャンセルイベント
+    /// </summary>
+    public class ActionCanceledEvent : GameEvent
+    {
+        public string ActionName { get; }
+        public ActionCanceledEvent(string actionName)
+        {
+            ActionName = actionName;
+        }
+    }
+}

--- a/Scripts/Systems/Player/Input/EnhancedInputProcessor.cs
+++ b/Scripts/Systems/Player/Input/EnhancedInputProcessor.cs
@@ -1,0 +1,71 @@
+using Systems.Player.Events;
+using Core.Events;
+using Godot;
+
+namespace Systems.Player.Input
+{
+    /// <summary>
+    /// 拡張された入力処理システム
+    /// </summary>
+    public class EnhancedInputProcessor
+    {
+        private readonly InputState _state = new();
+        private readonly InputBuffer _buffer;
+        private readonly IGameEventBus _event_bus;
+
+        public EnhancedInputProcessor(IGameEventBus bus)
+        {
+            _event_bus = bus;
+            _buffer = new InputBuffer(bus);
+        }
+
+        /// <summary>
+        /// 入力を更新して処理する
+        /// </summary>
+        public void Update()
+        {
+            _state.Update();
+            if (_state.ButtonStates.TryGetValue("Dash", out var dash) && dash)
+            {
+                _buffer.BufferAction("Dash");
+            }
+            if (_state.ButtonStates.TryGetValue("Jump", out var jump) && jump)
+            {
+                _buffer.BufferAction("Jump");
+            }
+            if (_state.ButtonStates.TryGetValue("Attack", out var atk) && atk)
+            {
+                _buffer.BufferAction("Attack");
+            }
+            if (_state.MovementInput != Vector2.Zero)
+            {
+                _buffer.BufferMovement(_state.MovementInput);
+            }
+
+            var action = _buffer.PopAction();
+            if (action != null)
+            {
+                switch (action)
+                {
+                    case "Dash":
+                        _event_bus.Publish(new DashInputEvent());
+                        break;
+                    case "Jump":
+                        _event_bus.Publish(new JumpInputEvent());
+                        break;
+                    case "Attack":
+                        _event_bus.Publish(new AttackInputEvent());
+                        break;
+                }
+            }
+
+            var move = _buffer.GetMovement();
+            if (move != Vector2.Zero)
+            {
+                _event_bus.Publish(new MovementInputEvent(move.Normalized()));
+            }
+
+            _event_bus.Publish(new InputStateChangedEvent(_state));
+        }
+    }
+}

--- a/Scripts/Systems/Player/Input/EnhancedInputProcessor.cs
+++ b/Scripts/Systems/Player/Input/EnhancedInputProcessor.cs
@@ -16,7 +16,7 @@ namespace Systems.Player.Input
         public EnhancedInputProcessor(IGameEventBus bus)
         {
             _event_bus = bus;
-            _buffer = new InputBuffer(bus);
+            _buffer = new InputBuffer();
         }
 
         /// <summary>

--- a/Scripts/Systems/Player/Input/InputBuffer.cs
+++ b/Scripts/Systems/Player/Input/InputBuffer.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using Core.Events;
+using Godot;
+
+namespace Systems.Player.Input
+{
+    /// <summary>
+    /// 入力バッファリングシステム
+    /// </summary>
+    public class InputBuffer
+    {
+        private readonly InputRingBuffer<string> _action_buffer = new(12);
+        private readonly InputRingBuffer<Vector2> _movement_buffer = new(12);
+
+        public InputBuffer(IGameEventBus bus)
+        {
+        }
+
+        /// <summary>
+        /// アクション入力をバッファする
+        /// </summary>
+        public void BufferAction(string action)
+        {
+            _action_buffer.Add(action);
+        }
+
+        /// <summary>
+        /// 移動入力をバッファする
+        /// </summary>
+        public void BufferMovement(Vector2 dir)
+        {
+            _movement_buffer.Add(dir);
+        }
+
+        /// <summary>
+        /// 優先度順にアクションを取得する
+        /// </summary>
+        public string? PopAction()
+        {
+            foreach (var a in _action_buffer.GetItems())
+            {
+                if (a == "Dash") return a;
+            }
+            foreach (var a in _action_buffer.GetItems())
+            {
+                if (a == "Jump") return a;
+            }
+            foreach (var a in _action_buffer.GetItems())
+            {
+                if (a == "Attack") return a;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// 最新の移動入力を取得する
+        /// </summary>
+        public Vector2 GetMovement()
+        {
+            return _movement_buffer.GetItems().LastOrDefault();
+        }
+    }
+}

--- a/Scripts/Systems/Player/Input/InputBuffer.cs
+++ b/Scripts/Systems/Player/Input/InputBuffer.cs
@@ -12,7 +12,7 @@ namespace Systems.Player.Input
         private readonly InputRingBuffer<string> _action_buffer = new(12);
         private readonly InputRingBuffer<Vector2> _movement_buffer = new(12);
 
-        public InputBuffer(IGameEventBus bus)
+        public InputBuffer()
         {
         }
 
@@ -39,15 +39,27 @@ namespace Systems.Player.Input
         {
             foreach (var a in _action_buffer.GetItems())
             {
-                if (a == "Dash") return a;
+                if (a == "Dash")
+                {
+                    _action_buffer.Clear();
+                    return a;
+                }
             }
             foreach (var a in _action_buffer.GetItems())
             {
-                if (a == "Jump") return a;
+                if (a == "Jump")
+                {
+                    _action_buffer.Clear();
+                    return a;
+                }
             }
             foreach (var a in _action_buffer.GetItems())
             {
-                if (a == "Attack") return a;
+                if (a == "Attack")
+                {
+                    _action_buffer.Clear();
+                    return a;
+                }
             }
             return null;
         }

--- a/Scripts/Systems/Player/Input/InputBuffer.cs
+++ b/Scripts/Systems/Player/Input/InputBuffer.cs
@@ -37,31 +37,29 @@ namespace Systems.Player.Input
         /// </summary>
         public string? PopAction()
         {
+            string? selected = null;
+            var best = int.MaxValue;
             foreach (var a in _action_buffer.GetItems())
             {
-                if (a == "Dash")
+                var priority = a switch
                 {
-                    _action_buffer.Clear();
-                    return a;
+                    "Dash" => 0,
+                    "Jump" => 1,
+                    "Attack" => 2,
+                    _ => int.MaxValue
+                };
+                if (priority < best)
+                {
+                    selected = a;
+                    best = priority;
                 }
             }
-            foreach (var a in _action_buffer.GetItems())
+
+            if (selected != null)
             {
-                if (a == "Jump")
-                {
-                    _action_buffer.Clear();
-                    return a;
-                }
+                _action_buffer.Clear();
             }
-            foreach (var a in _action_buffer.GetItems())
-            {
-                if (a == "Attack")
-                {
-                    _action_buffer.Clear();
-                    return a;
-                }
-            }
-            return null;
+            return selected;
         }
 
         /// <summary>

--- a/Scripts/Systems/Player/Input/InputRingBuffer.cs
+++ b/Scripts/Systems/Player/Input/InputRingBuffer.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+
+namespace Systems.Player.Input
+{
+    /// <summary>
+    /// リングバッファによる入力管理クラス
+    /// </summary>
+    public class InputRingBuffer<T>
+    {
+        private readonly T[] _buffer;
+        private int _head;
+        private int _count;
+
+        public int Capacity => _buffer.Length;
+        public int Count => _count;
+
+        public InputRingBuffer(int capacity = 12)
+        {
+            _buffer = new T[capacity];
+        }
+
+        /// <summary>
+        /// バッファに追加する
+        /// </summary>
+        public void Add(T item)
+        {
+            _buffer[_head] = item;
+            _head = (_head + 1) % Capacity;
+            if (_count < Capacity)
+            {
+                _count++;
+            }
+        }
+
+        /// <summary>
+        /// すべての要素を取得する
+        /// </summary>
+        public IEnumerable<T> GetItems()
+        {
+            for (int i = 0; i < _count; i++)
+            {
+                int index = (_head - _count + i + Capacity) % Capacity;
+                yield return _buffer[index];
+            }
+        }
+
+        /// <summary>
+        /// バッファをクリアする
+        /// </summary>
+        public void Clear()
+        {
+            _head = 0;
+            _count = 0;
+        }
+    }
+}

--- a/Scripts/Systems/Player/State/ActionFrameData.cs
+++ b/Scripts/Systems/Player/State/ActionFrameData.cs
@@ -14,10 +14,10 @@ namespace Systems.Player.State
         public int ActiveFrames { get; }
         public int RecoveryFrames { get; }
 
-        public ActionFrameData(string actionName, int startFrame, int totalFrames, int startupFrames, int activeFrames, int recoveryFrames)
+        public ActionFrameData(string actionName, int totalFrames, int startupFrames, int activeFrames, int recoveryFrames)
         {
             ActionName = actionName;
-            StartFrame = startFrame;
+            StartFrame = 0;
             TotalFrames = totalFrames;
             StartupFrames = startupFrames;
             ActiveFrames = activeFrames;

--- a/Scripts/Systems/Player/State/ActionFrameData.cs
+++ b/Scripts/Systems/Player/State/ActionFrameData.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace Systems.Player.State
+{
+    /// <summary>
+    /// アクションのフレームデータを管理するクラス
+    /// </summary>
+    public class ActionFrameData
+    {
+        public string ActionName { get; }
+        public int StartFrame { get; private set; }
+        public int TotalFrames { get; }
+        public int StartupFrames { get; }
+        public int ActiveFrames { get; }
+        public int RecoveryFrames { get; }
+
+        public ActionFrameData(string actionName, int startFrame, int totalFrames, int startupFrames, int activeFrames, int recoveryFrames)
+        {
+            ActionName = actionName;
+            StartFrame = startFrame;
+            TotalFrames = totalFrames;
+            StartupFrames = startupFrames;
+            ActiveFrames = activeFrames;
+            RecoveryFrames = recoveryFrames;
+        }
+
+        /// <summary>
+        /// 開始フレームを設定する
+        /// </summary>
+        public void SetStartFrame(int frame)
+        {
+            StartFrame = frame;
+        }
+
+        /// <summary>
+        /// スタートアップフレームか判定する
+        /// </summary>
+        public bool IsStartup(int currentFrame)
+        {
+            var offset = currentFrame - StartFrame;
+            return offset >= 0 && offset < StartupFrames;
+        }
+
+        /// <summary>
+        /// アクティブフレームか判定する
+        /// </summary>
+        public bool IsActive(int currentFrame)
+        {
+            var offset = currentFrame - StartFrame;
+            return offset >= StartupFrames && offset < StartupFrames + ActiveFrames;
+        }
+
+        /// <summary>
+        /// リカバリーフレームか判定する
+        /// </summary>
+        public bool IsRecovery(int currentFrame)
+        {
+            var offset = currentFrame - StartFrame;
+            return offset >= StartupFrames + ActiveFrames && offset < TotalFrames;
+        }
+    }
+}

--- a/Scripts/Systems/Player/State/FrameStateManager.cs
+++ b/Scripts/Systems/Player/State/FrameStateManager.cs
@@ -1,0 +1,64 @@
+using Core.Events;
+using Systems.Player.Events;
+
+namespace Systems.Player.State
+{
+    /// <summary>
+    /// フレーム単位の状態管理を行うクラス
+    /// </summary>
+    public class FrameStateManager
+    {
+        private int _current_frame;
+        private ActionFrameData? _current_action;
+        private readonly IGameEventBus _event_bus;
+
+        public int CurrentFrame => _current_frame;
+        public ActionFrameData? CurrentAction => _current_action;
+
+        public FrameStateManager(IGameEventBus eventBus)
+        {
+            _event_bus = eventBus;
+        }
+
+        /// <summary>
+        /// フレームを進める
+        /// </summary>
+        public void Tick()
+        {
+            _current_frame++;
+            _event_bus.Publish(new FrameAdvancedEvent(_current_frame));
+            CheckActionEnd();
+        }
+
+        /// <summary>
+        /// アクション開始
+        /// </summary>
+        public void StartAction(ActionFrameData data)
+        {
+            data.SetStartFrame(_current_frame);
+            _current_action = data;
+            _event_bus.Publish(new ActionStartedEvent(data.ActionName));
+        }
+
+        private void CheckActionEnd()
+        {
+            if (_current_action == null) return;
+            if (_current_frame - _current_action.StartFrame >= _current_action.TotalFrames)
+            {
+                var name = _current_action.ActionName;
+                _current_action = null;
+                _event_bus.Publish(new ActionEndedEvent(name));
+            }
+        }
+
+        /// <summary>
+        /// キャンセル可能か判定する
+        /// </summary>
+        public bool IsInCancelableFrame(int start, int end)
+        {
+            if (_current_action == null) return false;
+            var offset = _current_frame - _current_action.StartFrame;
+            return offset >= start && offset <= end;
+        }
+    }
+}

--- a/Scripts/Systems/Player/State/PlayerStateMachine.cs
+++ b/Scripts/Systems/Player/State/PlayerStateMachine.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Reactive.Linq;
+using Core.Events;
+using Systems.Common.Events;
+using Systems.Player.Events;
+
+namespace Systems.Player.State
+{
+    /// <summary>
+    /// プレイヤーの状態遷移を管理するクラス
+    /// </summary>
+    public class PlayerStateMachine
+    {
+        private readonly FrameStateManager _frame_manager;
+        private readonly IGameEventBus _event_bus;
+        private string _current_state = "Idle";
+
+        public string CurrentState => _current_state;
+
+        public PlayerStateMachine(FrameStateManager frameManager, IGameEventBus eventBus)
+        {
+            _frame_manager = frameManager;
+            _event_bus = eventBus;
+        }
+
+        /// <summary>
+        /// 初期化処理
+        /// </summary>
+        public void Initialize()
+        {
+            _event_bus.GetEventStream<ActionEndedEvent>()
+                .Subscribe(OnActionEnded);
+            _event_bus.Publish(new StateChangedEvent(_current_state));
+        }
+
+        /// <summary>
+        /// 状態を更新する
+        /// </summary>
+        public void Update()
+        {
+            _frame_manager.Tick();
+        }
+
+        /// <summary>
+        /// アクション開始
+        /// </summary>
+        public void StartAction(ActionFrameData data)
+        {
+            _current_state = data.ActionName;
+            _frame_manager.StartAction(data);
+            _event_bus.Publish(new StateChangedEvent(_current_state));
+        }
+
+        private void OnActionEnded(ActionEndedEvent evt)
+        {
+            _current_state = "Idle";
+            _event_bus.Publish(new StateChangedEvent(_current_state));
+        }
+    }
+}

--- a/Tests/Core/Player/Combat/CancelRuleManagerTests.cs
+++ b/Tests/Core/Player/Combat/CancelRuleManagerTests.cs
@@ -15,7 +15,7 @@ namespace Tests.Core.Player.Combat
             var ruleManager = new CancelRuleManager(frameManager);
             ruleManager.InitializeDefaultRules();
 
-            var action = new ActionFrameData("Attack_L1", 0, 30, 5, 10, 15);
+            var action = new ActionFrameData("Attack_L1", 30, 5, 10, 15);
             frameManager.StartAction(action);
             for (int i = 0; i < 15; i++) frameManager.Tick();
             Assert.IsTrue(ruleManager.CanCancel("Dodge"));
@@ -29,7 +29,7 @@ namespace Tests.Core.Player.Combat
             var ruleManager = new CancelRuleManager(frameManager);
             ruleManager.InitializeDefaultRules();
 
-            var action = new ActionFrameData("Attack_L1", 0, 30, 5, 10, 15);
+            var action = new ActionFrameData("Attack_L1", 30, 5, 10, 15);
             frameManager.StartAction(action);
             for (int i = 0; i < 10; i++) frameManager.Tick();
             Assert.IsFalse(ruleManager.CanCancel("Dodge"));

--- a/Tests/Core/Player/Combat/CancelRuleManagerTests.cs
+++ b/Tests/Core/Player/Combat/CancelRuleManagerTests.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+using Systems.Player.Combat;
+using Systems.Player.State;
+using Core.Events;
+
+namespace Tests.Core.Player.Combat
+{
+    public class CancelRuleManagerTests
+    {
+        [Test]
+        public void CanCancel_ReturnsTrueWhenRuleMatches()
+        {
+            var bus = new GameEventBus();
+            var frameManager = new FrameStateManager(bus);
+            var ruleManager = new CancelRuleManager(frameManager);
+            ruleManager.InitializeDefaultRules();
+
+            var action = new ActionFrameData("Attack_L1", 0, 30, 5, 10, 15);
+            frameManager.StartAction(action);
+            for (int i = 0; i < 15; i++) frameManager.Tick();
+            Assert.IsTrue(ruleManager.CanCancel("Dodge"));
+        }
+
+        [Test]
+        public void CanCancel_ReturnsFalseOutsideFrame()
+        {
+            var bus = new GameEventBus();
+            var frameManager = new FrameStateManager(bus);
+            var ruleManager = new CancelRuleManager(frameManager);
+            ruleManager.InitializeDefaultRules();
+
+            var action = new ActionFrameData("Attack_L1", 0, 30, 5, 10, 15);
+            frameManager.StartAction(action);
+            for (int i = 0; i < 10; i++) frameManager.Tick();
+            Assert.IsFalse(ruleManager.CanCancel("Dodge"));
+        }
+    }
+}

--- a/Tests/Core/Player/Input/InputBufferTests.cs
+++ b/Tests/Core/Player/Input/InputBufferTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using Systems.Player.Input;
+
+namespace Tests.Core.Player.Input
+{
+    public class InputBufferTests
+    {
+        [Test]
+        public void PopAction_ReturnsHighestPriority()
+        {
+            var buffer = new InputBuffer();
+            buffer.BufferAction("Attack");
+            buffer.BufferAction("Dash");
+            buffer.BufferAction("Jump");
+            var action = buffer.PopAction();
+            Assert.AreEqual("Dash", action);
+        }
+
+        [Test]
+        public void PopAction_ClearsBuffer()
+        {
+            var buffer = new InputBuffer();
+            buffer.BufferAction("Jump");
+            var first = buffer.PopAction();
+            var second = buffer.PopAction();
+            Assert.AreEqual("Jump", first);
+            Assert.IsNull(second);
+        }
+    }
+}

--- a/Tests/Core/Player/Input/InputRingBufferTests.cs
+++ b/Tests/Core/Player/Input/InputRingBufferTests.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+using Systems.Player.Input;
+
+namespace Tests.Core.Player.Input
+{
+    public class InputRingBufferTests
+    {
+        [Test]
+        public void Add_OverCapacity_OverwritesOldest()
+        {
+            var buffer = new InputRingBuffer<int>(3);
+            buffer.Add(1);
+            buffer.Add(2);
+            buffer.Add(3);
+            buffer.Add(4);
+            var items = buffer.GetItems();
+            CollectionAssert.AreEqual(new[] {2,3,4}, items);
+        }
+    }
+}

--- a/Tests/Core/Player/State/FrameStateManagerTests.cs
+++ b/Tests/Core/Player/State/FrameStateManagerTests.cs
@@ -21,7 +21,7 @@ namespace Tests.Core.Player.State
         {
             var bus = new GameEventBus();
             var manager = new FrameStateManager(bus);
-            var data = new ActionFrameData("Test", 0, 10, 1, 5, 4);
+            var data = new ActionFrameData("Test", 10, 1, 5, 4);
             manager.StartAction(data);
             Assert.That(manager.CurrentAction, Is.Not.Null);
             Assert.That(manager.CurrentAction!.ActionName, Is.EqualTo("Test"));
@@ -32,7 +32,7 @@ namespace Tests.Core.Player.State
         {
             var bus = new GameEventBus();
             var manager = new FrameStateManager(bus);
-            var data = new ActionFrameData("Test", 0, 10, 1, 5, 4);
+            var data = new ActionFrameData("Test", 10, 1, 5, 4);
             manager.StartAction(data);
             for (int i = 0; i < 5; i++) manager.Tick();
             Assert.IsTrue(manager.IsInCancelableFrame(2, 5));

--- a/Tests/Core/Player/State/FrameStateManagerTests.cs
+++ b/Tests/Core/Player/State/FrameStateManagerTests.cs
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+using Systems.Player.State;
+using Systems.Player.Events;
+using Core.Events;
+
+namespace Tests.Core.Player.State
+{
+    public class FrameStateManagerTests
+    {
+        [Test]
+        public void Tick_IncrementsFrame()
+        {
+            var bus = new GameEventBus();
+            var manager = new FrameStateManager(bus);
+            manager.Tick();
+            Assert.That(manager.CurrentFrame, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void StartAction_SetsCurrentAction()
+        {
+            var bus = new GameEventBus();
+            var manager = new FrameStateManager(bus);
+            var data = new ActionFrameData("Test", 0, 10, 1, 5, 4);
+            manager.StartAction(data);
+            Assert.That(manager.CurrentAction, Is.Not.Null);
+            Assert.That(manager.CurrentAction!.ActionName, Is.EqualTo("Test"));
+        }
+
+        [Test]
+        public void IsInCancelableFrame_ReturnsTrueWithinRange()
+        {
+            var bus = new GameEventBus();
+            var manager = new FrameStateManager(bus);
+            var data = new ActionFrameData("Test", 0, 10, 1, 5, 4);
+            manager.StartAction(data);
+            for (int i = 0; i < 5; i++) manager.Tick();
+            Assert.IsTrue(manager.IsInCancelableFrame(2, 5));
+        }
+    }
+}


### PR DESCRIPTION
## 概要
- フレーム管理 `FrameStateManager` などプレイヤー状態拡張を実装
- キャンセルルールやアクション実行管理を追加
- 入力バッファリング用 `InputRingBuffer` などを実装
- `ActionExecutionManager` の重複イベント送信を削除
- GameEventBus をテストから利用できるよう公開コンストラクタを追加
- 変数名を snake_case に統一

## テスト方法
- `./setup_godot_cli.sh`
- `dotnet test Tests/Core/CoreTests.csproj --no-build`

## 影響範囲
- Player システム全般

------
https://chatgpt.com/codex/tasks/task_e_685549cc42f8832395e7c924ea015269