### PR TITLE
feat: ダンジョン生成システムの機能拡張実装 (Week 2)

### DIFF
--- a/Docs/06_DevelopmentPlan/11_18_week2_dungeon_extension_plan.md
+++ b/Docs/06_DevelopmentPlan/11_18_week2_dungeon_extension_plan.md
@@ -1,8 +1,8 @@
 ---
 title: Week 2: ダンジョン生成システム機能拡張実装計画
-version: 0.1.0
-status: draft
-updated: 2025-06-20
+version: 0.2.0
+status: in-progress
+updated: 2026-07-17
 tags:
     - Implementation
     - Plan
@@ -193,5 +193,6 @@ Week 1で構築したダンジョン生成基盤を拡張し、ゲームプレ�
 
 | バージョン | 更新日     | 変更内容 |
 | ---------- | ---------- | -------- |
+| 0.2.0      | 2026-07-17 | Phase 1-4 実装完了を反映<br>- Gimmicks（GimmickPlacementModel/GimmickActivator/HiddenPassageGimmick/LockedDoorGimmick）、Navigation（NavigationMesh/NavigationNode/PathFinder/NavigationManager）、TileMap（TileType/TileTemplate/TileSetManager/RoomTileGenerator/TileMapManager/TileRenderer）、ViewModels+Events（DungeonViewModel/RoomViewModel/DungeonEvents）を実装<br>- `dotnet test` 196件全pass<br>- テストは計画書記載の `Tests/Systems/Dungeon/` ではなく `Tests/Core/Dungeon/{Gimmicks,Navigation,TileMap,ViewModels}` に配置（Week 1からの既存規約に統一）<br>- 未実施: GUTテスト（TileMapManager/TileRendererはGodotノード依存のため薄いラッパーに留め、ロジックはNUnitでカバーする方針としGDScript側のGUTテストは見送り）、実際の`.tres`タイルセット資産の作成（プレースホルダーのアトラス座標マッピングのみ）、テストカバレッジ計測、パフォーマンス/メモリ計測、API仕様書等の別ドキュメント作成 |
 | 0.1.0      | 2025-06-20 | 初版作成<br>- Week 2機能拡張実装計画<br>- ギミック・ナビゲーション・タイルマップ・ViewModel統合<br>- 7日間の日別実装スケジュール<br>- テスト戦略とリスク管理 |
 

--- a/Scripts/Systems/Dungeon/Data/RoomData.cs
+++ b/Scripts/Systems/Dungeon/Data/RoomData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Godot;
 
 namespace Systems.Dungeon.Data
@@ -55,6 +56,16 @@ namespace Systems.Dungeon.Data
         public void AddGimmick(GimmickData gimmick)
         {
             Gimmicks.Add(gimmick);
+        }
+
+        /// <summary>
+        /// 指定した接続先部屋位置に対応する扉を取得する
+        /// </summary>
+        /// <param name="connectedRoomPosition">接続先の部屋の位置</param>
+        /// <returns>対応する扉データ。見つからない場合は null</returns>
+        public DoorData? GetDoorTo(Vector2I connectedRoomPosition)
+        {
+            return Doors.FirstOrDefault(d => d.ConnectedRoomPosition == connectedRoomPosition);
         }
     }
 }

--- a/Scripts/Systems/Dungeon/Events/DungeonEvents.cs
+++ b/Scripts/Systems/Dungeon/Events/DungeonEvents.cs
@@ -1,0 +1,146 @@
+using Core.Events;
+using Godot;
+using Systems.Dungeon.Data;
+
+namespace Systems.Dungeon.Events
+{
+    /// <summary>
+    /// レベル生成完了イベント
+    /// ダンジョン全体の部屋生成・ギミック配置・ナビゲーションメッシュ構築が完了した際に発行される
+    /// </summary>
+    public class LevelGeneratedEvent : GameEvent
+    {
+        /// <summary>
+        /// 生成された部屋数
+        /// </summary>
+        public int RoomCount { get; }
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="roomCount">生成された部屋数</param>
+        public LevelGeneratedEvent(int roomCount)
+        {
+            RoomCount = roomCount;
+        }
+    }
+
+    /// <summary>
+    /// 部屋入室イベント
+    /// プレイヤーが部屋に入室した際に発行される
+    /// </summary>
+    public class RoomEnteredEvent : GameEvent
+    {
+        /// <summary>
+        /// 入室した部屋の位置
+        /// </summary>
+        public Vector2I RoomPosition { get; }
+
+        /// <summary>
+        /// 入室した部屋の種類
+        /// </summary>
+        public RoomType RoomType { get; }
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="roomPosition">入室した部屋の位置</param>
+        /// <param name="roomType">入室した部屋の種類</param>
+        public RoomEnteredEvent(Vector2I roomPosition, RoomType roomType)
+        {
+            RoomPosition = roomPosition;
+            RoomType = roomType;
+        }
+    }
+
+    /// <summary>
+    /// 隠し通路発見イベント
+    /// 隠し通路ギミックが発見・開通した際に発行される
+    /// </summary>
+    public class HiddenPassageRevealedEvent : GameEvent
+    {
+        /// <summary>
+        /// ギミックが属する部屋の位置
+        /// </summary>
+        public Vector2I RoomPosition { get; }
+
+        /// <summary>
+        /// 発動したギミックの位置
+        /// </summary>
+        public Vector2I GimmickPosition { get; }
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="roomPosition">ギミックが属する部屋の位置</param>
+        /// <param name="gimmickPosition">発動したギミックの位置</param>
+        public HiddenPassageRevealedEvent(Vector2I roomPosition, Vector2I gimmickPosition)
+        {
+            RoomPosition = roomPosition;
+            GimmickPosition = gimmickPosition;
+        }
+    }
+
+    /// <summary>
+    /// 鍵扉解錠イベント
+    /// 鍵扉ギミックが解錠された際に発行される
+    /// </summary>
+    public class LockedDoorUnlockedEvent : GameEvent
+    {
+        /// <summary>
+        /// ギミックが属する部屋の位置
+        /// </summary>
+        public Vector2I RoomPosition { get; }
+
+        /// <summary>
+        /// 発動したギミックの位置
+        /// </summary>
+        public Vector2I GimmickPosition { get; }
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="roomPosition">ギミックが属する部屋の位置</param>
+        /// <param name="gimmickPosition">発動したギミックの位置</param>
+        public LockedDoorUnlockedEvent(Vector2I roomPosition, Vector2I gimmickPosition)
+        {
+            RoomPosition = roomPosition;
+            GimmickPosition = gimmickPosition;
+        }
+    }
+
+    /// <summary>
+    /// ギミック発動失敗イベント
+    /// ギミックの発動条件を満たさなかった場合（既に発動済み・鍵不足など）に発行される
+    /// </summary>
+    public class GimmickActivationFailedEvent : GameEvent
+    {
+        /// <summary>
+        /// ギミックが属する部屋の位置
+        /// </summary>
+        public Vector2I RoomPosition { get; }
+
+        /// <summary>
+        /// 発動に失敗したギミックの位置
+        /// </summary>
+        public Vector2I GimmickPosition { get; }
+
+        /// <summary>
+        /// 発動に失敗したギミックの種類
+        /// </summary>
+        public GimmickType GimmickType { get; }
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="roomPosition">ギミックが属する部屋の位置</param>
+        /// <param name="gimmickPosition">発動に失敗したギミックの位置</param>
+        /// <param name="gimmickType">発動に失敗したギミックの種類</param>
+        public GimmickActivationFailedEvent(Vector2I roomPosition, Vector2I gimmickPosition, GimmickType gimmickType)
+        {
+            RoomPosition = roomPosition;
+            GimmickPosition = gimmickPosition;
+            GimmickType = gimmickType;
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/Gimmicks/GimmickActivator.cs
+++ b/Scripts/Systems/Dungeon/Gimmicks/GimmickActivator.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Godot;
+using Systems.Dungeon.Data;
+
+namespace Systems.Dungeon.Gimmicks
+{
+    /// <summary>
+    /// ギミック発動管理
+    /// 配置済みギミック（隠し通路・鍵扉）の発動可否判定と状態遷移を担う
+    /// イベント発行は行わず、戻り値と部屋データの状態変化のみで結果を表現する
+    /// </summary>
+    public class GimmickActivator
+    {
+        /// <summary>
+        /// 隠し通路ギミックを発動する
+        /// 発動に成功すると、対象ギミックと接続先の対応するギミックの両方を有効化し、
+        /// 対応する扉（自室・接続先の両側）を通常の扉（<see cref="DoorType.Normal"/>）に変更する
+        /// </summary>
+        /// <param name="rooms">部屋データの辞書（部屋位置がキー）</param>
+        /// <param name="roomPosition">ギミックが属する部屋の位置</param>
+        /// <param name="gimmickPosition">発動対象のギミックの位置</param>
+        /// <returns>発動に成功した場合は true。ギミックが存在しない、種類が異なる、既に発動済みの場合は false</returns>
+        public bool TryActivateHiddenPassage(Dictionary<Vector2I, RoomData> rooms, Vector2I roomPosition, Vector2I gimmickPosition)
+        {
+            if (!TryFindGimmick(rooms, roomPosition, gimmickPosition, out var room, out var gimmick) ||
+                !HiddenPassageGimmick.CanActivate(gimmick))
+            {
+                return false;
+            }
+
+            var door = room.Doors.FirstOrDefault(d => d.Position == gimmickPosition);
+            if (door == null)
+            {
+                return false;
+            }
+
+            gimmick!.IsActive = true;
+            door.Type = DoorType.Normal;
+
+            if (rooms.TryGetValue(door.ConnectedRoomPosition, out var connectedRoom))
+            {
+                var connectedDoor = connectedRoom.Doors.FirstOrDefault(d => d.ConnectedRoomPosition == roomPosition);
+                if (connectedDoor != null)
+                {
+                    connectedDoor.Type = DoorType.Normal;
+
+                    var connectedGimmick = connectedRoom.Gimmicks.FirstOrDefault(
+                        g => g.Type == GimmickType.HiddenPassage && g.Position == connectedDoor.Position);
+                    if (connectedGimmick != null)
+                    {
+                        connectedGimmick.IsActive = true;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// 鍵扉ギミックを発動（解錠）する
+        /// 発動に成功すると、対象ギミックと接続先の対応するギミックの両方を有効化し、
+        /// 対応する扉（自室・接続先の両側）の施錠を解除する（扉の種類は <see cref="DoorType.Locked"/> のまま据え置く）
+        /// </summary>
+        /// <param name="rooms">部屋データの辞書（部屋位置がキー）</param>
+        /// <param name="roomPosition">ギミックが属する部屋の位置</param>
+        /// <param name="gimmickPosition">発動対象のギミックの位置</param>
+        /// <param name="hasKey">鍵を所持しているかどうか（鍵アイテムシステムは Week2 範囲外のため呼び出し側の判定結果を受け取る）</param>
+        /// <returns>発動に成功した場合は true。鍵を所持していない、ギミックが存在しない、既に発動済みの場合は false</returns>
+        public bool TryActivateLockedDoor(Dictionary<Vector2I, RoomData> rooms, Vector2I roomPosition, Vector2I gimmickPosition, bool hasKey)
+        {
+            if (!TryFindGimmick(rooms, roomPosition, gimmickPosition, out var room, out var gimmick) ||
+                !LockedDoorGimmick.CanActivate(gimmick, hasKey))
+            {
+                return false;
+            }
+
+            var door = room.Doors.FirstOrDefault(d => d.Position == gimmickPosition);
+            if (door == null)
+            {
+                return false;
+            }
+
+            gimmick!.IsActive = true;
+            door.IsLocked = false;
+
+            if (rooms.TryGetValue(door.ConnectedRoomPosition, out var connectedRoom))
+            {
+                var connectedDoor = connectedRoom.Doors.FirstOrDefault(d => d.ConnectedRoomPosition == roomPosition);
+                if (connectedDoor != null)
+                {
+                    connectedDoor.IsLocked = false;
+
+                    var connectedGimmick = connectedRoom.Gimmicks.FirstOrDefault(
+                        g => g.Type == GimmickType.LockedDoor && g.Position == connectedDoor.Position);
+                    if (connectedGimmick != null)
+                    {
+                        connectedGimmick.IsActive = true;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// 指定した部屋・位置に該当するギミックデータを探す
+        /// </summary>
+        /// <param name="rooms">部屋データの辞書</param>
+        /// <param name="roomPosition">ギミックが属する部屋の位置</param>
+        /// <param name="gimmickPosition">探索対象のギミックの位置</param>
+        /// <param name="room">見つかった部屋データ（見つからない場合は null）</param>
+        /// <param name="gimmick">見つかったギミックデータ（見つからない場合は null）</param>
+        /// <returns>部屋・ギミックの両方が見つかった場合は true</returns>
+        private static bool TryFindGimmick(
+            Dictionary<Vector2I, RoomData> rooms,
+            Vector2I roomPosition,
+            Vector2I gimmickPosition,
+            [NotNullWhen(true)] out RoomData? room,
+            [NotNullWhen(true)] out GimmickData? gimmick)
+        {
+            if (!rooms.TryGetValue(roomPosition, out room))
+            {
+                gimmick = null;
+                return false;
+            }
+
+            gimmick = room.Gimmicks.FirstOrDefault(g => g.Position == gimmickPosition);
+            return gimmick != null;
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/Gimmicks/GimmickActivator.cs
+++ b/Scripts/Systems/Dungeon/Gimmicks/GimmickActivator.cs
@@ -17,11 +17,12 @@ namespace Systems.Dungeon.Gimmicks
         /// 隠し通路ギミックを発動する
         /// 発動に成功すると、対象ギミックと接続先の対応するギミックの両方を有効化し、
         /// 対応する扉（自室・接続先の両側）を通常の扉（<see cref="DoorType.Normal"/>）に変更する
+        /// 接続先の部屋・扉・ギミックが見つからない場合は、どちらの側も変更せずに失敗を返す
         /// </summary>
         /// <param name="rooms">部屋データの辞書（部屋位置がキー）</param>
         /// <param name="roomPosition">ギミックが属する部屋の位置</param>
         /// <param name="gimmickPosition">発動対象のギミックの位置</param>
-        /// <returns>発動に成功した場合は true。ギミックが存在しない、種類が異なる、既に発動済みの場合は false</returns>
+        /// <returns>発動に成功した場合は true。ギミックが存在しない、種類が異なる、既に発動済み、接続先の対応データが見つからない場合は false</returns>
         public bool TryActivateHiddenPassage(Dictionary<Vector2I, RoomData> rooms, Vector2I roomPosition, Vector2I gimmickPosition)
         {
             if (!TryFindGimmick(rooms, roomPosition, gimmickPosition, out var room, out var gimmick) ||
@@ -31,29 +32,16 @@ namespace Systems.Dungeon.Gimmicks
             }
 
             var door = room.Doors.FirstOrDefault(d => d.Position == gimmickPosition);
-            if (door == null)
+            if (door == null ||
+                !TryFindConnectedGimmick(rooms, roomPosition, door, GimmickType.HiddenPassage, out var connectedDoor, out var connectedGimmick))
             {
                 return false;
             }
 
-            gimmick!.IsActive = true;
+            gimmick.IsActive = true;
             door.Type = DoorType.Normal;
-
-            if (rooms.TryGetValue(door.ConnectedRoomPosition, out var connectedRoom))
-            {
-                var connectedDoor = connectedRoom.Doors.FirstOrDefault(d => d.ConnectedRoomPosition == roomPosition);
-                if (connectedDoor != null)
-                {
-                    connectedDoor.Type = DoorType.Normal;
-
-                    var connectedGimmick = connectedRoom.Gimmicks.FirstOrDefault(
-                        g => g.Type == GimmickType.HiddenPassage && g.Position == connectedDoor.Position);
-                    if (connectedGimmick != null)
-                    {
-                        connectedGimmick.IsActive = true;
-                    }
-                }
-            }
+            connectedDoor.Type = DoorType.Normal;
+            connectedGimmick.IsActive = true;
 
             return true;
         }
@@ -62,12 +50,13 @@ namespace Systems.Dungeon.Gimmicks
         /// 鍵扉ギミックを発動（解錠）する
         /// 発動に成功すると、対象ギミックと接続先の対応するギミックの両方を有効化し、
         /// 対応する扉（自室・接続先の両側）の施錠を解除する（扉の種類は <see cref="DoorType.Locked"/> のまま据え置く）
+        /// 接続先の部屋・扉・ギミックが見つからない場合は、どちらの側も変更せずに失敗を返す
         /// </summary>
         /// <param name="rooms">部屋データの辞書（部屋位置がキー）</param>
         /// <param name="roomPosition">ギミックが属する部屋の位置</param>
         /// <param name="gimmickPosition">発動対象のギミックの位置</param>
         /// <param name="hasKey">鍵を所持しているかどうか（鍵アイテムシステムは Week2 範囲外のため呼び出し側の判定結果を受け取る）</param>
-        /// <returns>発動に成功した場合は true。鍵を所持していない、ギミックが存在しない、既に発動済みの場合は false</returns>
+        /// <returns>発動に成功した場合は true。鍵を所持していない、ギミックが存在しない、既に発動済み、接続先の対応データが見つからない場合は false</returns>
         public bool TryActivateLockedDoor(Dictionary<Vector2I, RoomData> rooms, Vector2I roomPosition, Vector2I gimmickPosition, bool hasKey)
         {
             if (!TryFindGimmick(rooms, roomPosition, gimmickPosition, out var room, out var gimmick) ||
@@ -77,31 +66,57 @@ namespace Systems.Dungeon.Gimmicks
             }
 
             var door = room.Doors.FirstOrDefault(d => d.Position == gimmickPosition);
-            if (door == null)
+            if (door == null ||
+                !TryFindConnectedGimmick(rooms, roomPosition, door, GimmickType.LockedDoor, out var connectedDoor, out var connectedGimmick))
             {
                 return false;
             }
 
-            gimmick!.IsActive = true;
+            gimmick.IsActive = true;
             door.IsLocked = false;
-
-            if (rooms.TryGetValue(door.ConnectedRoomPosition, out var connectedRoom))
-            {
-                var connectedDoor = connectedRoom.Doors.FirstOrDefault(d => d.ConnectedRoomPosition == roomPosition);
-                if (connectedDoor != null)
-                {
-                    connectedDoor.IsLocked = false;
-
-                    var connectedGimmick = connectedRoom.Gimmicks.FirstOrDefault(
-                        g => g.Type == GimmickType.LockedDoor && g.Position == connectedDoor.Position);
-                    if (connectedGimmick != null)
-                    {
-                        connectedGimmick.IsActive = true;
-                    }
-                }
-            }
+            connectedDoor.IsLocked = false;
+            connectedGimmick.IsActive = true;
 
             return true;
+        }
+
+        /// <summary>
+        /// 指定した扉の接続先の部屋から、対となる扉と対応するギミックを探す
+        /// 接続先の部屋・対となる扉・対応するギミックのいずれかが見つからない場合は失敗する
+        /// </summary>
+        /// <param name="rooms">部屋データの辞書（部屋位置がキー）</param>
+        /// <param name="roomPosition">発動元の部屋の位置</param>
+        /// <param name="door">発動対象の扉（発動元の部屋に属する）</param>
+        /// <param name="gimmickType">探索対象のギミックの種類</param>
+        /// <param name="connectedDoor">見つかった接続先の扉（見つからない場合は null）</param>
+        /// <param name="connectedGimmick">見つかった接続先のギミック（見つからない場合は null）</param>
+        /// <returns>接続先の扉・ギミックの両方が見つかった場合は true</returns>
+        private static bool TryFindConnectedGimmick(
+            Dictionary<Vector2I, RoomData> rooms,
+            Vector2I roomPosition,
+            DoorData door,
+            GimmickType gimmickType,
+            [NotNullWhen(true)] out DoorData? connectedDoor,
+            [NotNullWhen(true)] out GimmickData? connectedGimmick)
+        {
+            connectedGimmick = null;
+
+            if (!rooms.TryGetValue(door.ConnectedRoomPosition, out var connectedRoom))
+            {
+                connectedDoor = null;
+                return false;
+            }
+
+            connectedDoor = connectedRoom.GetDoorTo(roomPosition);
+            if (connectedDoor == null)
+            {
+                return false;
+            }
+
+            var connectedDoorPosition = connectedDoor.Position;
+            connectedGimmick = connectedRoom.Gimmicks.FirstOrDefault(
+                g => g.Type == gimmickType && g.Position == connectedDoorPosition);
+            return connectedGimmick != null;
         }
 
         /// <summary>

--- a/Scripts/Systems/Dungeon/Gimmicks/GimmickPlacementModel.cs
+++ b/Scripts/Systems/Dungeon/Gimmicks/GimmickPlacementModel.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Godot;
+using Systems.Dungeon.Data;
+
+namespace Systems.Dungeon.Gimmicks
+{
+    /// <summary>
+    /// ギミック配置モデル
+    /// 生成・接続済みの部屋データに対し、隠し通路（HiddenPassage）と鍵扉（LockedDoor）ギミックを配置する
+    /// </summary>
+    public class GimmickPlacementModel
+    {
+        /// <summary>
+        /// 鍵扉候補の選定・決定に使用する乱数（テスト再現性のため注入する）
+        /// </summary>
+        private readonly Random random;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="random">ギミック配置処理に使用する乱数生成器</param>
+        /// <exception cref="ArgumentNullException">random が null の場合</exception>
+        public GimmickPlacementModel(Random random)
+        {
+            this.random = random ?? throw new ArgumentNullException(nameof(random));
+        }
+
+        /// <summary>
+        /// 部屋データにギミックを配置する
+        /// 隠し部屋（Secret）に接続する扉を隠し通路化し、続けて宝物部屋・ボス部屋（Treasure/Boss）に接続する扉のうち
+        /// 開始部屋（Start）に隣接せず隠し扉化されていないものから 1 つを選んで鍵扉化する
+        /// </summary>
+        /// <param name="rooms">配置対象の部屋データの辞書（部屋位置がキー、接続済みであること）</param>
+        /// <exception cref="ArgumentNullException">rooms が null の場合</exception>
+        public void PlaceGimmicks(Dictionary<Vector2I, RoomData> rooms)
+        {
+            if (rooms == null)
+            {
+                throw new ArgumentNullException(nameof(rooms));
+            }
+
+            PlaceHiddenPassages(rooms);
+            PlaceLockedDoor(rooms);
+        }
+
+        /// <summary>
+        /// 隠し部屋（Secret）に接続する扉をすべて隠し扉化し、両側の部屋に隠し通路ギミックを追加する
+        /// </summary>
+        /// <param name="rooms">配置対象の部屋データの辞書</param>
+        private static void PlaceHiddenPassages(Dictionary<Vector2I, RoomData> rooms)
+        {
+            // 固定順（座標順）で処理し、シード再現性を確保する
+            foreach (var position in rooms.Keys.OrderBy(p => p.X).ThenBy(p => p.Y))
+            {
+                var room = rooms[position];
+                if (room.Type != RoomType.Secret)
+                {
+                    continue;
+                }
+
+                foreach (var door in room.Doors.OrderBy(d => d.Position.X).ThenBy(d => d.Position.Y))
+                {
+                    if (!rooms.TryGetValue(door.ConnectedRoomPosition, out var connectedRoom))
+                    {
+                        continue;
+                    }
+
+                    var connectedDoor = connectedRoom.Doors.FirstOrDefault(d => d.ConnectedRoomPosition == position);
+                    if (connectedDoor == null)
+                    {
+                        continue;
+                    }
+
+                    door.Type = DoorType.Secret;
+                    door.IsLocked = false;
+                    connectedDoor.Type = DoorType.Secret;
+                    connectedDoor.IsLocked = false;
+
+                    room.AddGimmick(new GimmickData
+                    {
+                        Position = door.Position,
+                        Type = GimmickType.HiddenPassage,
+                        IsActive = false
+                    });
+
+                    connectedRoom.AddGimmick(new GimmickData
+                    {
+                        Position = connectedDoor.Position,
+                        Type = GimmickType.HiddenPassage,
+                        IsActive = false
+                    });
+                }
+            }
+        }
+
+        /// <summary>
+        /// 宝物部屋・ボス部屋（Treasure/Boss）に接続する扉から候補を集め、乱数で 1 つ選んで鍵扉化する
+        /// 開始部屋（Start）に隣接する扉、および既に隠し扉化された扉は候補から除外する
+        /// 候補が存在しない場合は何もしない
+        /// </summary>
+        /// <param name="rooms">配置対象の部屋データの辞書</param>
+        private void PlaceLockedDoor(Dictionary<Vector2I, RoomData> rooms)
+        {
+            var candidates = CollectLockedDoorCandidates(rooms);
+            if (candidates.Count == 0)
+            {
+                return;
+            }
+
+            var (room, door, connectedRoom, connectedDoor) = candidates[random.Next(candidates.Count)];
+
+            door.Type = DoorType.Locked;
+            door.IsLocked = true;
+            connectedDoor.Type = DoorType.Locked;
+            connectedDoor.IsLocked = true;
+
+            room.AddGimmick(new GimmickData
+            {
+                Position = door.Position,
+                Type = GimmickType.LockedDoor,
+                IsActive = false
+            });
+
+            connectedRoom.AddGimmick(new GimmickData
+            {
+                Position = connectedDoor.Position,
+                Type = GimmickType.LockedDoor,
+                IsActive = false
+            });
+        }
+
+        /// <summary>
+        /// 鍵扉候補となる扉ペア（両側の部屋・扉）の一覧を座標順で固定して収集する
+        /// 各辺（部屋間の接続）は 1 度だけ候補に含める
+        /// </summary>
+        /// <param name="rooms">探索対象の部屋データの辞書</param>
+        /// <returns>候補となる (部屋, 扉, 接続先部屋, 接続先扉) のタプルの一覧（座標順）</returns>
+        private static List<(RoomData Room, DoorData Door, RoomData ConnectedRoom, DoorData ConnectedDoor)> CollectLockedDoorCandidates(
+            Dictionary<Vector2I, RoomData> rooms)
+        {
+            var candidates = new List<(RoomData, DoorData, RoomData, DoorData)>();
+
+            // 固定順（座標順）で処理し、シード再現性を確保する
+            foreach (var position in rooms.Keys.OrderBy(p => p.X).ThenBy(p => p.Y))
+            {
+                var room = rooms[position];
+
+                foreach (var door in room.Doors.OrderBy(d => d.Position.X).ThenBy(d => d.Position.Y))
+                {
+                    if (door.Type == DoorType.Secret)
+                    {
+                        continue;
+                    }
+
+                    if (!rooms.TryGetValue(door.ConnectedRoomPosition, out var connectedRoom))
+                    {
+                        continue;
+                    }
+
+                    // 各辺を 1 度だけ候補にするため、座標順で自分が先（小さい側）の場合のみ処理する
+                    if (!IsBefore(position, door.ConnectedRoomPosition))
+                    {
+                        continue;
+                    }
+
+                    if (room.Type == RoomType.Start || connectedRoom.Type == RoomType.Start)
+                    {
+                        continue;
+                    }
+
+                    bool leadsToTreasureOrBoss =
+                        room.Type == RoomType.Treasure || room.Type == RoomType.Boss ||
+                        connectedRoom.Type == RoomType.Treasure || connectedRoom.Type == RoomType.Boss;
+                    if (!leadsToTreasureOrBoss)
+                    {
+                        continue;
+                    }
+
+                    var connectedDoor = connectedRoom.Doors.FirstOrDefault(d => d.ConnectedRoomPosition == position);
+                    if (connectedDoor == null || connectedDoor.Type == DoorType.Secret)
+                    {
+                        continue;
+                    }
+
+                    candidates.Add((room, door, connectedRoom, connectedDoor));
+                }
+            }
+
+            return candidates;
+        }
+
+        /// <summary>
+        /// 座標順（X 優先、次に Y）で a が b より前かどうかを判定する
+        /// </summary>
+        /// <param name="a">比較対象の位置 A</param>
+        /// <param name="b">比較対象の位置 B</param>
+        /// <returns>a が b より座標順で前であれば true</returns>
+        private static bool IsBefore(Vector2I a, Vector2I b)
+        {
+            return a.X != b.X ? a.X < b.X : a.Y < b.Y;
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/Gimmicks/GimmickPlacementModel.cs
+++ b/Scripts/Systems/Dungeon/Gimmicks/GimmickPlacementModel.cs
@@ -67,7 +67,7 @@ namespace Systems.Dungeon.Gimmicks
                         continue;
                     }
 
-                    var connectedDoor = connectedRoom.Doors.FirstOrDefault(d => d.ConnectedRoomPosition == position);
+                    var connectedDoor = connectedRoom.GetDoorTo(position);
                     if (connectedDoor == null)
                     {
                         continue;
@@ -178,7 +178,7 @@ namespace Systems.Dungeon.Gimmicks
                         continue;
                     }
 
-                    var connectedDoor = connectedRoom.Doors.FirstOrDefault(d => d.ConnectedRoomPosition == position);
+                    var connectedDoor = connectedRoom.GetDoorTo(position);
                     if (connectedDoor == null || connectedDoor.Type == DoorType.Secret)
                     {
                         continue;

--- a/Scripts/Systems/Dungeon/Gimmicks/HiddenPassageGimmick.cs
+++ b/Scripts/Systems/Dungeon/Gimmicks/HiddenPassageGimmick.cs
@@ -1,0 +1,26 @@
+using Systems.Dungeon.Data;
+
+namespace Systems.Dungeon.Gimmicks
+{
+    /// <summary>
+    /// 隠し通路ギミック
+    /// 発見されるまでは隠し扉として振る舞い、発動すると通常の扉として開通するギミックのドメインロジックを表す
+    /// </summary>
+    public static class HiddenPassageGimmick
+    {
+        /// <summary>
+        /// このギミックの効果を説明するテキスト
+        /// </summary>
+        public const string Description = "隠された通路。発見して発動すると通常の扉として開通する。";
+
+        /// <summary>
+        /// 指定したギミックが発動可能かどうかを判定する
+        /// </summary>
+        /// <param name="gimmick">判定対象のギミックデータ（null の場合は発動不可）</param>
+        /// <returns>種類が隠し通路（<see cref="GimmickType.HiddenPassage"/>）かつ未発動であれば true</returns>
+        public static bool CanActivate(GimmickData? gimmick)
+        {
+            return gimmick != null && gimmick.Type == GimmickType.HiddenPassage && !gimmick.IsActive;
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/Gimmicks/LockedDoorGimmick.cs
+++ b/Scripts/Systems/Dungeon/Gimmicks/LockedDoorGimmick.cs
@@ -1,0 +1,27 @@
+using Systems.Dungeon.Data;
+
+namespace Systems.Dungeon.Gimmicks
+{
+    /// <summary>
+    /// 鍵扉ギミック
+    /// 鍵を所持している場合のみ解錠できる扉ギミックのドメインロジックを表す
+    /// </summary>
+    public static class LockedDoorGimmick
+    {
+        /// <summary>
+        /// このギミックの効果を説明するテキスト
+        /// </summary>
+        public const string Description = "鍵のかかった扉。鍵を所持した状態で発動すると解錠される。";
+
+        /// <summary>
+        /// 指定したギミックが発動（解錠）可能かどうかを判定する
+        /// </summary>
+        /// <param name="gimmick">判定対象のギミックデータ（null の場合は発動不可）</param>
+        /// <param name="hasKey">鍵を所持しているかどうか</param>
+        /// <returns>鍵を所持しており、種類が鍵扉（<see cref="GimmickType.LockedDoor"/>）かつ未発動であれば true</returns>
+        public static bool CanActivate(GimmickData? gimmick, bool hasKey)
+        {
+            return hasKey && gimmick != null && gimmick.Type == GimmickType.LockedDoor && !gimmick.IsActive;
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/Models/RoomConnectionModel.cs
+++ b/Scripts/Systems/Dungeon/Models/RoomConnectionModel.cs
@@ -102,7 +102,7 @@ namespace Systems.Dungeon.Models
                         return false;
                     }
 
-                    if (!connectedRoom.Doors.Any(d => d.ConnectedRoomPosition == position))
+                    if (connectedRoom.GetDoorTo(position) == null)
                     {
                         return false;
                     }

--- a/Scripts/Systems/Dungeon/Navigation/NavigationManager.cs
+++ b/Scripts/Systems/Dungeon/Navigation/NavigationManager.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using Godot;
+using Systems.Dungeon.Data;
+using Systems.Dungeon.Models;
+
+namespace Systems.Dungeon.Navigation
+{
+    /// <summary>
+    /// ナビゲーション管理
+    /// <see cref="NavigationMesh"/> の生成・保持と経路探索の窓口となる
+    /// レベル生成直後、およびギミック発動後（扉の状態が変わった後）に <see cref="BuildMesh"/> を呼び出す想定
+    /// </summary>
+    public class NavigationManager
+    {
+        /// <summary>
+        /// 通行可能領域を保持するナビゲーションメッシュ
+        /// </summary>
+        private readonly NavigationMesh navigationMesh = new();
+
+        /// <summary>
+        /// ナビゲーションメッシュ上で経路探索を行う探索器
+        /// </summary>
+        private readonly PathFinder pathFinder;
+
+        /// <summary>
+        /// コンストラクタ
+        /// 内部のナビゲーションメッシュと、それを参照する経路探索器を初期化する
+        /// </summary>
+        public NavigationManager()
+        {
+            pathFinder = new PathFinder(navigationMesh);
+        }
+
+        /// <summary>
+        /// ナビゲーションメッシュを（再）構築する
+        /// レベル生成直後、およびギミック発動後（扉の状態が変わった後）に呼び出すことで
+        /// 通行可能領域を最新の状態に更新する
+        /// </summary>
+        /// <param name="rooms">部屋データの辞書（部屋位置がキー）</param>
+        /// <param name="roomTemplates">部屋テンプレートの辞書（部屋位置がキー）</param>
+        public void BuildMesh(Dictionary<Vector2I, RoomData> rooms, IReadOnlyDictionary<Vector2I, RoomTemplate> roomTemplates)
+        {
+            navigationMesh.Build(rooms, roomTemplates);
+        }
+
+        /// <summary>
+        /// 現在のナビゲーションメッシュ上で開始地点から目標地点までの経路を探索する
+        /// </summary>
+        /// <param name="start">開始地点のワールドタイル座標</param>
+        /// <param name="goal">目標地点のワールドタイル座標</param>
+        /// <returns>開始地点から目標地点までの経路（両端を含む）。経路が存在しない場合は空リスト</returns>
+        public List<Vector2I> FindPath(Vector2I start, Vector2I goal)
+        {
+            return pathFinder.FindPath(start, goal);
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/Navigation/NavigationMesh.cs
+++ b/Scripts/Systems/Dungeon/Navigation/NavigationMesh.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using Godot;
+using Systems.Dungeon.Data;
+using Systems.Dungeon.Models;
+using Systems.Dungeon.Utilities;
+
+namespace Systems.Dungeon.Navigation
+{
+    /// <summary>
+    /// ナビゲーションメッシュ
+    /// ダンジョン全体の「通行可能なワールドタイル座標の集合」を構築・保持する
+    /// 部屋内部の床領域（障害物を除く）と、通行可能な状態の扉のみを通行可能として扱う
+    /// </summary>
+    public class NavigationMesh
+    {
+        /// <summary>
+        /// 通行可能なワールドタイル座標の集合
+        /// </summary>
+        private readonly HashSet<Vector2I> walkableTiles = new();
+
+        /// <summary>
+        /// 通行可能集合を構築する
+        /// 呼び出しのたびに集合をクリアしてから再構築するため、扉の状態変化後（ギミック発動後）に
+        /// 再呼び出しすることでメッシュを最新の状態に更新できる
+        /// </summary>
+        /// <param name="rooms">部屋データの辞書（部屋位置がキー）</param>
+        /// <param name="roomTemplates">部屋テンプレートの辞書（部屋位置がキー、障害物のローカル座標を保持）</param>
+        /// <exception cref="ArgumentNullException">rooms または roomTemplates が null の場合</exception>
+        public void Build(Dictionary<Vector2I, RoomData> rooms, IReadOnlyDictionary<Vector2I, RoomTemplate> roomTemplates)
+        {
+            if (rooms == null)
+            {
+                throw new ArgumentNullException(nameof(rooms));
+            }
+
+            if (roomTemplates == null)
+            {
+                throw new ArgumentNullException(nameof(roomTemplates));
+            }
+
+            walkableTiles.Clear();
+
+            foreach (var (position, room) in rooms)
+            {
+                roomTemplates.TryGetValue(position, out var template);
+                AddRoomFloor(room, template);
+                AddWalkableDoors(room);
+            }
+        }
+
+        /// <summary>
+        /// 指定したワールドタイル座標が通行可能かどうかを判定する
+        /// </summary>
+        /// <param name="worldPosition">判定対象のワールドタイル座標</param>
+        /// <returns>通行可能集合に含まれる場合は true</returns>
+        public bool IsWalkable(Vector2I worldPosition)
+        {
+            return walkableTiles.Contains(worldPosition);
+        }
+
+        /// <summary>
+        /// 指定したワールドタイル座標に上下左右（斜め移動なし）で隣接し、かつ通行可能なタイル座標を列挙する
+        /// </summary>
+        /// <param name="worldPosition">基準となるワールドタイル座標</param>
+        /// <returns>通行可能な隣接タイル座標の列挙</returns>
+        public IEnumerable<Vector2I> GetWalkableNeighbors(Vector2I worldPosition)
+        {
+            foreach (var offset in Offsets)
+            {
+                var neighbor = worldPosition + offset;
+                if (walkableTiles.Contains(neighbor))
+                {
+                    yield return neighbor;
+                }
+            }
+        }
+
+        /// <summary>
+        /// 上下左右 4 方向の座標オフセット（斜め移動なし）
+        /// </summary>
+        private static readonly Vector2I[] Offsets =
+        {
+            new(1, 0), new(-1, 0), new(0, 1), new(0, -1)
+        };
+
+        /// <summary>
+        /// 部屋内部の床領域（障害物を除く）をワールド座標に変換して通行可能集合へ追加する
+        /// テンプレートが見つからない場合は障害物なしとして内部領域全体を追加する
+        /// </summary>
+        /// <param name="room">対象の部屋データ</param>
+        /// <param name="template">対象の部屋テンプレート（見つからない場合は null）</param>
+        private void AddRoomFloor(RoomData room, RoomTemplate? template)
+        {
+            var obstacles = template?.ObstaclePositions;
+
+            for (int x = 1; x <= DungeonConstants.ROOM_SIZE - 2; x++)
+            {
+                for (int y = 1; y <= DungeonConstants.ROOM_SIZE - 2; y++)
+                {
+                    var local = new Vector2I(x, y);
+                    if (obstacles != null && obstacles.Contains(local))
+                    {
+                        continue;
+                    }
+
+                    walkableTiles.Add(room.Position + local);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 通行可能な状態（<see cref="DoorType.Secret"/> ではなく、かつ施錠されていない）の扉のみを
+        /// 通行可能集合へ追加する
+        /// </summary>
+        /// <param name="room">対象の部屋データ</param>
+        private void AddWalkableDoors(RoomData room)
+        {
+            foreach (var door in room.Doors)
+            {
+                if (door.Type != DoorType.Secret && !door.IsLocked)
+                {
+                    walkableTiles.Add(door.Position);
+                }
+            }
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/Navigation/NavigationNode.cs
+++ b/Scripts/Systems/Dungeon/Navigation/NavigationNode.cs
@@ -1,0 +1,37 @@
+using Godot;
+
+namespace Systems.Dungeon.Navigation
+{
+    /// <summary>
+    /// ナビゲーションノード
+    /// A* 探索における探索過程の状態（位置・コスト・経路復元用の親ノード）を保持する
+    /// プレーンなデータ保持クラスであり、A* アルゴリズム自体は <see cref="PathFinder"/> に実装する
+    /// </summary>
+    public class NavigationNode
+    {
+        /// <summary>
+        /// ノードのワールドタイル座標
+        /// </summary>
+        public Vector2I Position { get; set; }
+
+        /// <summary>
+        /// 開始地点からこのノードまでの実コスト
+        /// </summary>
+        public float GCost { get; set; }
+
+        /// <summary>
+        /// このノードから目標地点までのヒューリスティックコスト（マンハッタン距離を想定）
+        /// </summary>
+        public float HCost { get; set; }
+
+        /// <summary>
+        /// 総推定コスト（GCost + HCost）
+        /// </summary>
+        public float FCost => GCost + HCost;
+
+        /// <summary>
+        /// 経路復元に使用する直前のノード（開始ノードの場合は null）
+        /// </summary>
+        public NavigationNode? Parent { get; set; }
+    }
+}

--- a/Scripts/Systems/Dungeon/Navigation/PathFinder.cs
+++ b/Scripts/Systems/Dungeon/Navigation/PathFinder.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Godot;
+
+namespace Systems.Dungeon.Navigation
+{
+    /// <summary>
+    /// 経路探索器
+    /// <see cref="NavigationMesh"/> 上で A* アルゴリズムによる最短経路探索を行う
+    /// ヒューリスティックはマンハッタン距離、1 タイルの移動コストは 1 とする
+    /// </summary>
+    public class PathFinder
+    {
+        /// <summary>
+        /// 探索対象のナビゲーションメッシュ
+        /// </summary>
+        private readonly NavigationMesh navigationMesh;
+
+        /// <summary>
+        /// 1 タイル移動あたりのコスト
+        /// </summary>
+        private const float MOVE_COST = 1f;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="navigationMesh">経路探索に使用するナビゲーションメッシュ</param>
+        /// <exception cref="ArgumentNullException">navigationMesh が null の場合</exception>
+        public PathFinder(NavigationMesh navigationMesh)
+        {
+            this.navigationMesh = navigationMesh ?? throw new ArgumentNullException(nameof(navigationMesh));
+        }
+
+        /// <summary>
+        /// 開始地点から目標地点までの最短経路を A* アルゴリズムで探索する
+        /// </summary>
+        /// <param name="start">開始地点のワールドタイル座標</param>
+        /// <param name="goal">目標地点のワールドタイル座標</param>
+        /// <returns>
+        /// 開始地点から目標地点までの経路（両端を含み、開始 → 目標の順）
+        /// 開始・目標のいずれかが通行不可、または経路が存在しない場合は空リスト
+        /// </returns>
+        public List<Vector2I> FindPath(Vector2I start, Vector2I goal)
+        {
+            if (!navigationMesh.IsWalkable(start) || !navigationMesh.IsWalkable(goal))
+            {
+                return new List<Vector2I>();
+            }
+
+            if (start == goal)
+            {
+                return new List<Vector2I> { start };
+            }
+
+            var openNodes = new Dictionary<Vector2I, NavigationNode>();
+            var closedPositions = new HashSet<Vector2I>();
+
+            var startNode = new NavigationNode
+            {
+                Position = start,
+                GCost = 0f,
+                HCost = CalculateManhattanDistance(start, goal),
+                Parent = null
+            };
+            openNodes[start] = startNode;
+
+            while (openNodes.Count > 0)
+            {
+                var current = SelectLowestFCostNode(openNodes);
+
+                if (current.Position == goal)
+                {
+                    return BuildPath(current);
+                }
+
+                openNodes.Remove(current.Position);
+                closedPositions.Add(current.Position);
+
+                foreach (var neighborPosition in navigationMesh.GetWalkableNeighbors(current.Position))
+                {
+                    if (closedPositions.Contains(neighborPosition))
+                    {
+                        continue;
+                    }
+
+                    float tentativeGCost = current.GCost + MOVE_COST;
+
+                    if (openNodes.TryGetValue(neighborPosition, out var existingNode))
+                    {
+                        if (tentativeGCost < existingNode.GCost)
+                        {
+                            existingNode.GCost = tentativeGCost;
+                            existingNode.Parent = current;
+                        }
+                    }
+                    else
+                    {
+                        openNodes[neighborPosition] = new NavigationNode
+                        {
+                            Position = neighborPosition,
+                            GCost = tentativeGCost,
+                            HCost = CalculateManhattanDistance(neighborPosition, goal),
+                            Parent = current
+                        };
+                    }
+                }
+            }
+
+            return new List<Vector2I>();
+        }
+
+        /// <summary>
+        /// オープンリストから FCost が最小のノードを選ぶ（同値の場合は HCost が小さい方を優先する）
+        /// </summary>
+        /// <param name="openNodes">探索中のオープンリスト（座標をキーとする）</param>
+        /// <returns>FCost が最小のノード</returns>
+        private static NavigationNode SelectLowestFCostNode(Dictionary<Vector2I, NavigationNode> openNodes)
+        {
+            return openNodes.Values
+                .OrderBy(node => node.FCost)
+                .ThenBy(node => node.HCost)
+                .First();
+        }
+
+        /// <summary>
+        /// 2 点間のマンハッタン距離を計算する
+        /// </summary>
+        /// <param name="from">開始座標</param>
+        /// <param name="to">目標座標</param>
+        /// <returns>マンハッタン距離</returns>
+        private static float CalculateManhattanDistance(Vector2I from, Vector2I to)
+        {
+            return Math.Abs(from.X - to.X) + Math.Abs(from.Y - to.Y);
+        }
+
+        /// <summary>
+        /// 目標ノードから Parent を辿って開始 → 目標の順の経路リストを復元する
+        /// </summary>
+        /// <param name="goalNode">目標地点に到達したノード</param>
+        /// <returns>開始地点から目標地点までの座標のリスト</returns>
+        private static List<Vector2I> BuildPath(NavigationNode goalNode)
+        {
+            var path = new List<Vector2I>();
+            NavigationNode? current = goalNode;
+
+            while (current != null)
+            {
+                path.Add(current.Position);
+                current = current.Parent;
+            }
+
+            path.Reverse();
+            return path;
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/TileMap/RoomTileGenerator.cs
+++ b/Scripts/Systems/Dungeon/TileMap/RoomTileGenerator.cs
@@ -20,13 +20,14 @@ namespace Systems.Dungeon.TileMap
         /// <see cref="TileType.Obstacle"/>、それ以外は <see cref="TileType.Floor"/> とする
         /// 外周（部屋ローカル X/Y が 0 または ROOM_SIZE-1）は基本 <see cref="TileType.Wall"/> とし、
         /// <see cref="RoomTemplate.DoorPositions"/> に一致するセルは対応する扉（<see cref="RoomData.Doors"/>、インデックス対応）の
-        /// 種類に応じて <see cref="TileType.Door"/>・<see cref="TileType.LockedDoor"/>・<see cref="TileType.SecretWall"/> のいずれかとする
+        /// 種類・施錠状態に応じて <see cref="TileType.Door"/>・<see cref="TileType.LockedDoor"/>・<see cref="TileType.SecretWall"/> のいずれかとする
         /// すべてのセルは room.Position を加算したワールドタイル座標として返す
         /// </summary>
         /// <param name="room">対象の部屋データ</param>
         /// <param name="template">対象の部屋テンプレート（room.Doors と DoorPositions がインデックスで対応していること）</param>
         /// <returns>ワールドタイル座標とタイル種別の組の一覧</returns>
         /// <exception cref="ArgumentNullException">room または template が null の場合</exception>
+        /// <exception cref="InvalidOperationException">room.Doors と template.DoorPositions の件数が一致しない場合</exception>
         public List<(Vector2I WorldPosition, TileType Type)> GenerateTiles(RoomData room, RoomTemplate template)
         {
             if (room == null)
@@ -39,7 +40,7 @@ namespace Systems.Dungeon.TileMap
                 throw new ArgumentNullException(nameof(template));
             }
 
-            var doorTypeByLocalPosition = BuildDoorTypeMap(room, template);
+            var doorByLocalPosition = BuildDoorMap(room, template);
             var result = new List<(Vector2I WorldPosition, TileType Type)>();
 
             for (int x = 0; x < DungeonConstants.ROOM_SIZE; x++)
@@ -50,7 +51,7 @@ namespace Systems.Dungeon.TileMap
                     bool isBoundary = x == 0 || y == 0 || x == DungeonConstants.ROOM_SIZE - 1 || y == DungeonConstants.ROOM_SIZE - 1;
 
                     var type = isBoundary
-                        ? GetBoundaryTileType(local, doorTypeByLocalPosition)
+                        ? GetBoundaryTileType(local, doorByLocalPosition)
                         : GetInteriorTileType(local, template);
 
                     result.Add((room.Position + local, type));
@@ -61,20 +62,27 @@ namespace Systems.Dungeon.TileMap
         }
 
         /// <summary>
-        /// 扉のローカル座標から扉種別への対応表を構築する
+        /// 扉のローカル座標から扉データへの対応表を構築する
         /// <see cref="RoomTemplate.DoorPositions"/> と <see cref="RoomData.Doors"/> はインデックスで対応するため、
         /// 両者を先頭から順にペアリングして参照する
         /// </summary>
         /// <param name="room">対象の部屋データ</param>
         /// <param name="template">対象の部屋テンプレート</param>
-        /// <returns>扉のローカル座標をキーとした扉種別の辞書</returns>
-        private static Dictionary<Vector2I, DoorType> BuildDoorTypeMap(RoomData room, RoomTemplate template)
+        /// <returns>扉のローカル座標をキーとした扉データの辞書</returns>
+        /// <exception cref="InvalidOperationException">room.Doors と template.DoorPositions の件数が一致しない場合</exception>
+        private static Dictionary<Vector2I, DoorData> BuildDoorMap(RoomData room, RoomTemplate template)
         {
-            var map = new Dictionary<Vector2I, DoorType>();
-            int count = Math.Min(template.DoorPositions.Count, room.Doors.Count);
-            for (int i = 0; i < count; i++)
+            if (template.DoorPositions.Count != room.Doors.Count)
             {
-                map[template.DoorPositions[i]] = room.Doors[i].Type;
+                throw new InvalidOperationException(
+                    $"部屋テンプレートの扉数（{template.DoorPositions.Count}）と部屋データの扉数（{room.Doors.Count}）が一致しません。" +
+                    "RoomTemplate.DoorPositions と RoomData.Doors はインデックスで対応している必要があります。");
+            }
+
+            var map = new Dictionary<Vector2I, DoorData>();
+            for (int i = 0; i < template.DoorPositions.Count; i++)
+            {
+                map[template.DoorPositions[i]] = room.Doors[i];
             }
 
             return map;
@@ -82,24 +90,26 @@ namespace Systems.Dungeon.TileMap
 
         /// <summary>
         /// 外周セルのタイル種別を判定する
-        /// 扉のローカル座標に一致すれば扉種別に応じたタイル種別を、一致しなければ壁を返す
+        /// 扉のローカル座標に一致すれば扉の種類・施錠状態に応じたタイル種別を、一致しなければ壁を返す
+        /// 鍵扉は解錠後（<see cref="DoorData.IsLocked"/> が false）は <see cref="TileType.Door"/> として扱う
+        /// （<see cref="DoorData.Type"/> 自体は解錠後も <see cref="DoorType.Locked"/> のまま据え置かれるため、Type だけでは判定できない）
         /// </summary>
         /// <param name="local">判定対象の部屋ローカル座標</param>
-        /// <param name="doorTypeByLocalPosition">扉のローカル座標から扉種別への対応表</param>
+        /// <param name="doorByLocalPosition">扉のローカル座標から扉データへの対応表</param>
         /// <returns>外周セルのタイル種別</returns>
-        private static TileType GetBoundaryTileType(Vector2I local, Dictionary<Vector2I, DoorType> doorTypeByLocalPosition)
+        private static TileType GetBoundaryTileType(Vector2I local, Dictionary<Vector2I, DoorData> doorByLocalPosition)
         {
-            if (!doorTypeByLocalPosition.TryGetValue(local, out var doorType))
+            if (!doorByLocalPosition.TryGetValue(local, out var door))
             {
                 return TileType.Wall;
             }
 
-            return doorType switch
+            if (door.Type == DoorType.Secret)
             {
-                DoorType.Secret => TileType.SecretWall,
-                DoorType.Locked => TileType.LockedDoor,
-                _ => TileType.Door
-            };
+                return TileType.SecretWall;
+            }
+
+            return door.Type == DoorType.Locked && door.IsLocked ? TileType.LockedDoor : TileType.Door;
         }
 
         /// <summary>

--- a/Scripts/Systems/Dungeon/TileMap/RoomTileGenerator.cs
+++ b/Scripts/Systems/Dungeon/TileMap/RoomTileGenerator.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using Godot;
+using Systems.Dungeon.Data;
+using Systems.Dungeon.Models;
+using Systems.Dungeon.Utilities;
+
+namespace Systems.Dungeon.TileMap
+{
+    /// <summary>
+    /// 部屋タイル生成器
+    /// 部屋データと部屋テンプレートから、部屋 1 つ分の「ワールドタイル座標ごとのタイル種別」の配置を生成する
+    /// 座標変換とタイル種別判定のみを行う純粋ロジックであり、Godot ノードには依存しない
+    /// </summary>
+    public class RoomTileGenerator
+    {
+        /// <summary>
+        /// 部屋 1 つ分のタイル配置を生成する
+        /// 内部領域（部屋ローカル座標 1..ROOM_SIZE-2）は <see cref="RoomTemplate.ObstaclePositions"/> に含まれれば
+        /// <see cref="TileType.Obstacle"/>、それ以外は <see cref="TileType.Floor"/> とする
+        /// 外周（部屋ローカル X/Y が 0 または ROOM_SIZE-1）は基本 <see cref="TileType.Wall"/> とし、
+        /// <see cref="RoomTemplate.DoorPositions"/> に一致するセルは対応する扉（<see cref="RoomData.Doors"/>、インデックス対応）の
+        /// 種類に応じて <see cref="TileType.Door"/>・<see cref="TileType.LockedDoor"/>・<see cref="TileType.SecretWall"/> のいずれかとする
+        /// すべてのセルは room.Position を加算したワールドタイル座標として返す
+        /// </summary>
+        /// <param name="room">対象の部屋データ</param>
+        /// <param name="template">対象の部屋テンプレート（room.Doors と DoorPositions がインデックスで対応していること）</param>
+        /// <returns>ワールドタイル座標とタイル種別の組の一覧</returns>
+        /// <exception cref="ArgumentNullException">room または template が null の場合</exception>
+        public List<(Vector2I WorldPosition, TileType Type)> GenerateTiles(RoomData room, RoomTemplate template)
+        {
+            if (room == null)
+            {
+                throw new ArgumentNullException(nameof(room));
+            }
+
+            if (template == null)
+            {
+                throw new ArgumentNullException(nameof(template));
+            }
+
+            var doorTypeByLocalPosition = BuildDoorTypeMap(room, template);
+            var result = new List<(Vector2I WorldPosition, TileType Type)>();
+
+            for (int x = 0; x < DungeonConstants.ROOM_SIZE; x++)
+            {
+                for (int y = 0; y < DungeonConstants.ROOM_SIZE; y++)
+                {
+                    var local = new Vector2I(x, y);
+                    bool isBoundary = x == 0 || y == 0 || x == DungeonConstants.ROOM_SIZE - 1 || y == DungeonConstants.ROOM_SIZE - 1;
+
+                    var type = isBoundary
+                        ? GetBoundaryTileType(local, doorTypeByLocalPosition)
+                        : GetInteriorTileType(local, template);
+
+                    result.Add((room.Position + local, type));
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// 扉のローカル座標から扉種別への対応表を構築する
+        /// <see cref="RoomTemplate.DoorPositions"/> と <see cref="RoomData.Doors"/> はインデックスで対応するため、
+        /// 両者を先頭から順にペアリングして参照する
+        /// </summary>
+        /// <param name="room">対象の部屋データ</param>
+        /// <param name="template">対象の部屋テンプレート</param>
+        /// <returns>扉のローカル座標をキーとした扉種別の辞書</returns>
+        private static Dictionary<Vector2I, DoorType> BuildDoorTypeMap(RoomData room, RoomTemplate template)
+        {
+            var map = new Dictionary<Vector2I, DoorType>();
+            int count = Math.Min(template.DoorPositions.Count, room.Doors.Count);
+            for (int i = 0; i < count; i++)
+            {
+                map[template.DoorPositions[i]] = room.Doors[i].Type;
+            }
+
+            return map;
+        }
+
+        /// <summary>
+        /// 外周セルのタイル種別を判定する
+        /// 扉のローカル座標に一致すれば扉種別に応じたタイル種別を、一致しなければ壁を返す
+        /// </summary>
+        /// <param name="local">判定対象の部屋ローカル座標</param>
+        /// <param name="doorTypeByLocalPosition">扉のローカル座標から扉種別への対応表</param>
+        /// <returns>外周セルのタイル種別</returns>
+        private static TileType GetBoundaryTileType(Vector2I local, Dictionary<Vector2I, DoorType> doorTypeByLocalPosition)
+        {
+            if (!doorTypeByLocalPosition.TryGetValue(local, out var doorType))
+            {
+                return TileType.Wall;
+            }
+
+            return doorType switch
+            {
+                DoorType.Secret => TileType.SecretWall,
+                DoorType.Locked => TileType.LockedDoor,
+                _ => TileType.Door
+            };
+        }
+
+        /// <summary>
+        /// 内部領域セルのタイル種別を判定する
+        /// 障害物のローカル座標に含まれれば障害物を、含まれなければ床を返す
+        /// </summary>
+        /// <param name="local">判定対象の部屋ローカル座標</param>
+        /// <param name="template">対象の部屋テンプレート</param>
+        /// <returns>内部領域セルのタイル種別</returns>
+        private static TileType GetInteriorTileType(Vector2I local, RoomTemplate template)
+        {
+            return template.ObstaclePositions.Contains(local) ? TileType.Obstacle : TileType.Floor;
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/TileMap/TileMapManager.cs
+++ b/Scripts/Systems/Dungeon/TileMap/TileMapManager.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using Godot;
+
+namespace Systems.Dungeon.TileMap
+{
+    /// <summary>
+    /// タイルマップ管理
+    /// <see cref="RoomTileGenerator"/> が生成したタイル配置を実際の Godot <see cref="TileMapLayer"/> へ反映する薄いラッパー
+    /// タイル種別の判定・座標計算などのロジックは一切持たず、渡された配置をそのまま SetCell するだけに留める
+    /// </summary>
+    public partial class TileMapManager : Node
+    {
+        /// <summary>
+        /// 部屋 1 つ分のタイル配置を <see cref="TileMapLayer"/> へ反映する
+        /// </summary>
+        /// <param name="layer">反映先のタイルマップレイヤー</param>
+        /// <param name="placements">反映するワールドタイル座標とタイル種別の組の一覧（<see cref="RoomTileGenerator.GenerateTiles"/> の結果を想定）</param>
+        /// <param name="tileSetManager">タイル種別からソースID・アトラス座標を引くタイルセット管理</param>
+        public void ApplyTiles(TileMapLayer layer, IEnumerable<(Vector2I WorldPosition, TileType Type)> placements, TileSetManager tileSetManager)
+        {
+            foreach (var (worldPosition, type) in placements)
+            {
+                UpdateTile(layer, worldPosition, type, tileSetManager);
+            }
+        }
+
+        /// <summary>
+        /// 単一タイルを更新する
+        /// ギミック発動等で扉の状態が変わりタイル種別が動的に変化する場合に呼び出す想定
+        /// </summary>
+        /// <param name="layer">更新先のタイルマップレイヤー</param>
+        /// <param name="worldPosition">更新するワールドタイル座標</param>
+        /// <param name="type">更新後のタイル種別</param>
+        /// <param name="tileSetManager">タイル種別からソースID・アトラス座標を引くタイルセット管理</param>
+        public void UpdateTile(TileMapLayer layer, Vector2I worldPosition, TileType type, TileSetManager tileSetManager)
+        {
+            var template = tileSetManager.GetTemplate(type);
+            layer.SetCell(worldPosition, template.SourceId, template.AtlasCoords);
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/TileMap/TileRenderer.cs
+++ b/Scripts/Systems/Dungeon/TileMap/TileRenderer.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using Godot;
+
+namespace Systems.Dungeon.TileMap
+{
+    /// <summary>
+    /// タイル描画管理
+    /// 部屋単位の描画ノードを登録し、視界外の部屋の描画をスキップ（非表示化）する薄いGodotノードラッパー
+    /// フォグ・オブ・ウォー等の詳細な視界計算は行わず、部屋単位の表示/非表示切り替えのみを提供する
+    /// </summary>
+    public partial class TileRenderer : Node
+    {
+        /// <summary>
+        /// 部屋の位置から、その部屋の描画を担うノードへの対応表
+        /// </summary>
+        private readonly Dictionary<Vector2I, CanvasItem> roomLayers = new();
+
+        /// <summary>
+        /// 部屋の描画ノードを登録する
+        /// 同じ部屋位置で再登録した場合は登録内容を上書きする
+        /// </summary>
+        /// <param name="roomPosition">登録対象の部屋の位置</param>
+        /// <param name="layer">その部屋の描画を担うノード（<see cref="TileMapLayer"/> 等）</param>
+        public void RegisterRoomLayer(Vector2I roomPosition, CanvasItem layer)
+        {
+            roomLayers[roomPosition] = layer;
+        }
+
+        /// <summary>
+        /// 指定した部屋位置の描画の表示/非表示を切り替える
+        /// 対象の部屋が未登録の場合は何もしない
+        /// </summary>
+        /// <param name="roomPosition">対象の部屋の位置</param>
+        /// <param name="visible">表示する場合は true、非表示にする場合は false</param>
+        public void SetRoomVisible(Vector2I roomPosition, bool visible)
+        {
+            if (roomLayers.TryGetValue(roomPosition, out var layer))
+            {
+                layer.Visible = visible;
+            }
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/TileMap/TileSetManager.cs
+++ b/Scripts/Systems/Dungeon/TileMap/TileSetManager.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using Godot;
+
+namespace Systems.Dungeon.TileMap
+{
+    /// <summary>
+    /// タイルセット管理
+    /// <see cref="TileType"/> から <see cref="TileTemplate"/>（ソースID・アトラス座標）へのマッピングを管理する
+    /// 実際の .tres タイルセット資産がなくても検証できるよう、マッピングをコンストラクタから外部注入できる設計とする
+    /// </summary>
+    public class TileSetManager
+    {
+        /// <summary>
+        /// タイル種別からタイルテンプレートへのマッピング
+        /// </summary>
+        private readonly IReadOnlyDictionary<TileType, TileTemplate> templates;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="templates">
+        /// タイル種別ごとのテンプレートのマッピング。省略した場合は <see cref="CreateDefaultTemplates"/> による既定マッピングを使用する
+        /// </param>
+        public TileSetManager(IReadOnlyDictionary<TileType, TileTemplate>? templates = null)
+        {
+            this.templates = templates ?? CreateDefaultTemplates();
+        }
+
+        /// <summary>
+        /// 指定したタイル種別に対応するタイルテンプレートを取得する
+        /// </summary>
+        /// <param name="type">取得対象のタイル種別</param>
+        /// <returns>対応するタイルテンプレート</returns>
+        /// <exception cref="KeyNotFoundException">対応するテンプレートが登録されていない場合</exception>
+        public TileTemplate GetTemplate(TileType type)
+        {
+            return templates[type];
+        }
+
+        /// <summary>
+        /// 既定のタイル種別マッピングを生成する
+        /// 実際のタイルセット資産（アトラス座標）は未確定のため、ソースID 0 上の仮のアトラス座標を割り当てる
+        /// 見た目上の壁として扱う <see cref="TileType.SecretWall"/> は <see cref="TileType.Wall"/> と同じアトラス座標とする
+        /// </summary>
+        /// <returns>タイル種別ごとの既定タイルテンプレートのマッピング</returns>
+        private static IReadOnlyDictionary<TileType, TileTemplate> CreateDefaultTemplates()
+        {
+            return new Dictionary<TileType, TileTemplate>
+            {
+                [TileType.Floor] = new TileTemplate { Type = TileType.Floor, SourceId = 0, AtlasCoords = new Vector2I(0, 0) },
+                [TileType.Wall] = new TileTemplate { Type = TileType.Wall, SourceId = 0, AtlasCoords = new Vector2I(1, 0) },
+                [TileType.Door] = new TileTemplate { Type = TileType.Door, SourceId = 0, AtlasCoords = new Vector2I(2, 0) },
+                [TileType.LockedDoor] = new TileTemplate { Type = TileType.LockedDoor, SourceId = 0, AtlasCoords = new Vector2I(3, 0) },
+                [TileType.SecretWall] = new TileTemplate { Type = TileType.SecretWall, SourceId = 0, AtlasCoords = new Vector2I(1, 0) },
+                [TileType.Obstacle] = new TileTemplate { Type = TileType.Obstacle, SourceId = 0, AtlasCoords = new Vector2I(4, 0) }
+            };
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/TileMap/TileTemplate.cs
+++ b/Scripts/Systems/Dungeon/TileMap/TileTemplate.cs
@@ -1,0 +1,27 @@
+using Godot;
+
+namespace Systems.Dungeon.TileMap
+{
+    /// <summary>
+    /// タイルテンプレート
+    /// 論理タイル種別（<see cref="TileType"/>）と、実際のタイルセット上のソースID・アトラス座標の対応を表す
+    /// タイル種別の判定ロジックは持たず、単純な対応関係のみを保持する純粋なデータ保持クラス
+    /// </summary>
+    public class TileTemplate
+    {
+        /// <summary>
+        /// タイルの論理種別
+        /// </summary>
+        public TileType Type { get; set; }
+
+        /// <summary>
+        /// タイルセット上のソースID
+        /// </summary>
+        public int SourceId { get; set; }
+
+        /// <summary>
+        /// タイルセット上のアトラス座標
+        /// </summary>
+        public Vector2I AtlasCoords { get; set; }
+    }
+}

--- a/Scripts/Systems/Dungeon/TileMap/TileType.cs
+++ b/Scripts/Systems/Dungeon/TileMap/TileType.cs
@@ -1,0 +1,27 @@
+namespace Systems.Dungeon.TileMap
+{
+    /// <summary>
+    /// タイルの論理種別
+    /// 実際のタイルセット上のソースID・アトラス座標とは独立して、タイルの役割を表す
+    /// </summary>
+    public enum TileType
+    {
+        /// <summary>床</summary>
+        Floor,
+
+        /// <summary>壁</summary>
+        Wall,
+
+        /// <summary>通常の扉</summary>
+        Door,
+
+        /// <summary>鍵扉</summary>
+        LockedDoor,
+
+        /// <summary>未発見の隠し通路（見た目は壁として扱う）</summary>
+        SecretWall,
+
+        /// <summary>障害物</summary>
+        Obstacle
+    }
+}

--- a/Scripts/Systems/Dungeon/ViewModels/DungeonViewModel.cs
+++ b/Scripts/Systems/Dungeon/ViewModels/DungeonViewModel.cs
@@ -116,8 +116,8 @@ namespace Systems.Dungeon.ViewModels
 
         /// <summary>
         /// 隠し通路ギミックの発動を試みる
-        /// 発動に成功した場合はナビゲーションメッシュを再構築したうえで <see cref="HiddenPassageRevealedEvent"/> を、
-        /// 失敗した場合は <see cref="GimmickActivationFailedEvent"/>（<see cref="GimmickType.HiddenPassage"/>）を発行する
+        /// 発動に成功した場合はナビゲーションメッシュを再構築し、<see cref="Rooms"/> の変更を通知したうえで
+        /// <see cref="HiddenPassageRevealedEvent"/> を、失敗した場合は <see cref="GimmickActivationFailedEvent"/>（<see cref="GimmickType.HiddenPassage"/>）を発行する
         /// </summary>
         /// <param name="roomPosition">ギミックが属する部屋の位置</param>
         /// <param name="gimmickPosition">発動対象のギミックの位置</param>
@@ -127,6 +127,7 @@ namespace Systems.Dungeon.ViewModels
             if (_gimmickActivator.TryActivateHiddenPassage(Rooms.Value, roomPosition, gimmickPosition))
             {
                 _navigationManager.BuildMesh(Rooms.Value, _levelGenerationModel.RoomTemplates);
+                NotifyRoomsChanged();
                 EventBus.Publish(new HiddenPassageRevealedEvent(roomPosition, gimmickPosition));
                 return true;
             }
@@ -137,8 +138,8 @@ namespace Systems.Dungeon.ViewModels
 
         /// <summary>
         /// 鍵扉ギミックの発動（解錠）を試みる
-        /// 発動に成功した場合はナビゲーションメッシュを再構築したうえで <see cref="LockedDoorUnlockedEvent"/> を、
-        /// 失敗した場合は <see cref="GimmickActivationFailedEvent"/>（<see cref="GimmickType.LockedDoor"/>）を発行する
+        /// 発動に成功した場合はナビゲーションメッシュを再構築し、<see cref="Rooms"/> の変更を通知したうえで
+        /// <see cref="LockedDoorUnlockedEvent"/> を、失敗した場合は <see cref="GimmickActivationFailedEvent"/>（<see cref="GimmickType.LockedDoor"/>）を発行する
         /// </summary>
         /// <param name="roomPosition">ギミックが属する部屋の位置</param>
         /// <param name="gimmickPosition">発動対象のギミックの位置</param>
@@ -149,12 +150,24 @@ namespace Systems.Dungeon.ViewModels
             if (_gimmickActivator.TryActivateLockedDoor(Rooms.Value, roomPosition, gimmickPosition, hasKey))
             {
                 _navigationManager.BuildMesh(Rooms.Value, _levelGenerationModel.RoomTemplates);
+                NotifyRoomsChanged();
                 EventBus.Publish(new LockedDoorUnlockedEvent(roomPosition, gimmickPosition));
                 return true;
             }
 
             EventBus.Publish(new GimmickActivationFailedEvent(roomPosition, gimmickPosition, GimmickType.LockedDoor));
             return false;
+        }
+
+        /// <summary>
+        /// <see cref="Rooms"/> の変更を購読者に通知する
+        /// ギミック発動は <see cref="RoomData"/>/<see cref="DoorData"/> を in-place で書き換えるため、
+        /// 同一の辞書インスタンスを再代入するだけでは参照が変わらず <see cref="ReactiveProperty{T}"/> の変更検知（既定の等価比較）が
+        /// 働かない。新しい辞書インスタンスへ詰め替えて再代入することで、確実に変更通知を発火させる
+        /// </summary>
+        private void NotifyRoomsChanged()
+        {
+            Rooms.Value = new Dictionary<Vector2I, RoomData>(Rooms.Value);
         }
     }
 }

--- a/Scripts/Systems/Dungeon/ViewModels/DungeonViewModel.cs
+++ b/Scripts/Systems/Dungeon/ViewModels/DungeonViewModel.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Core.Events;
+using Core.Reactive;
+using Core.ViewModels;
+using Godot;
+using Systems.Dungeon.Data;
+using Systems.Dungeon.Events;
+using Systems.Dungeon.Gimmicks;
+using Systems.Dungeon.Models;
+using Systems.Dungeon.Navigation;
+
+namespace Systems.Dungeon.ViewModels
+{
+    /// <summary>
+    /// ダンジョンビューモデル
+    /// レベル生成（<see cref="LevelGenerationModel"/>）・ギミック配置（<see cref="GimmickPlacementModel"/>）・
+    /// ギミック発動（<see cref="GimmickActivator"/>）・ナビゲーション（<see cref="NavigationManager"/>）の
+    /// 各システムを統合し、ダンジョン全体の状態を View 層に公開してイベントを発行する
+    /// </summary>
+    public class DungeonViewModel : ViewModelBase
+    {
+        private readonly LevelGenerationModel _levelGenerationModel;
+        private readonly GimmickPlacementModel _gimmickPlacementModel;
+        private readonly GimmickActivator _gimmickActivator;
+        private readonly NavigationManager _navigationManager;
+
+        /// <summary>
+        /// 生成済みの部屋データ（部屋位置がキー）
+        /// View 層でのミニマップ表示等を想定した公開プロパティ
+        /// </summary>
+        public ReactiveProperty<Dictionary<Vector2I, RoomData>> Rooms { get; }
+
+        /// <summary>
+        /// 現在プレイヤーが位置する部屋の位置
+        /// </summary>
+        public ReactiveProperty<Vector2I> CurrentRoomPosition { get; }
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="levelGenerationModel">レベル生成モデル</param>
+        /// <param name="gimmickPlacementModel">ギミック配置モデル</param>
+        /// <param name="gimmickActivator">ギミック発動管理</param>
+        /// <param name="navigationManager">ナビゲーション管理</param>
+        /// <param name="eventBus">イベントバス</param>
+        /// <exception cref="ArgumentNullException">levelGenerationModel・gimmickPlacementModel・gimmickActivator・navigationManager のいずれかが null の場合</exception>
+        public DungeonViewModel(
+            LevelGenerationModel levelGenerationModel,
+            GimmickPlacementModel gimmickPlacementModel,
+            GimmickActivator gimmickActivator,
+            NavigationManager navigationManager,
+            IGameEventBus eventBus) : base(eventBus)
+        {
+            _levelGenerationModel = levelGenerationModel ?? throw new ArgumentNullException(nameof(levelGenerationModel));
+            _gimmickPlacementModel = gimmickPlacementModel ?? throw new ArgumentNullException(nameof(gimmickPlacementModel));
+            _gimmickActivator = gimmickActivator ?? throw new ArgumentNullException(nameof(gimmickActivator));
+            _navigationManager = navigationManager ?? throw new ArgumentNullException(nameof(navigationManager));
+
+            Rooms = new ReactiveProperty<Dictionary<Vector2I, RoomData>>(new Dictionary<Vector2I, RoomData>()).AddTo(Disposables);
+            CurrentRoomPosition = new ReactiveProperty<Vector2I>(Vector2I.Zero).AddTo(Disposables);
+        }
+
+        /// <summary>
+        /// ダンジョンのレベルを生成する
+        /// レベル生成 → ギミック配置 → ナビゲーションメッシュ構築の順に処理し、
+        /// 完了後に <see cref="Rooms"/>・<see cref="CurrentRoomPosition"/>（開始部屋 <see cref="Vector2I.Zero"/>）を更新して
+        /// <see cref="LevelGeneratedEvent"/> を発行する
+        /// </summary>
+        /// <param name="seed">レベル生成に使用する乱数シード値</param>
+        public async Task GenerateLevelAsync(int seed)
+        {
+            await ExecuteAsync(async () =>
+            {
+                _levelGenerationModel.SetSeed(seed);
+                var rooms = await _levelGenerationModel.GenerateLevelAsync();
+                _gimmickPlacementModel.PlaceGimmicks(rooms);
+                _navigationManager.BuildMesh(rooms, _levelGenerationModel.RoomTemplates);
+
+                Rooms.Value = rooms;
+                CurrentRoomPosition.Value = Vector2I.Zero;
+
+                EventBus.Publish(new LevelGeneratedEvent(rooms.Count));
+            });
+        }
+
+        /// <summary>
+        /// 開始地点から目標地点までの経路を探索する
+        /// </summary>
+        /// <param name="start">開始地点のワールドタイル座標</param>
+        /// <param name="goal">目標地点のワールドタイル座標</param>
+        /// <returns>開始地点から目標地点までの経路（両端を含む）。経路が存在しない場合は空リスト</returns>
+        public List<Vector2I> FindPath(Vector2I start, Vector2I goal)
+        {
+            return _navigationManager.FindPath(start, goal);
+        }
+
+        /// <summary>
+        /// 指定した部屋に入室する
+        /// 対象の部屋が存在する場合は <see cref="CurrentRoomPosition"/> を更新し、<see cref="RoomEnteredEvent"/> を発行する
+        /// </summary>
+        /// <param name="roomPosition">入室する部屋の位置</param>
+        /// <returns>入室に成功した場合は true。対象の部屋が存在しない場合は false</returns>
+        public bool EnterRoom(Vector2I roomPosition)
+        {
+            if (!Rooms.Value.TryGetValue(roomPosition, out var room))
+            {
+                return false;
+            }
+
+            CurrentRoomPosition.Value = roomPosition;
+            EventBus.Publish(new RoomEnteredEvent(roomPosition, room.Type));
+            return true;
+        }
+
+        /// <summary>
+        /// 隠し通路ギミックの発動を試みる
+        /// 発動に成功した場合はナビゲーションメッシュを再構築したうえで <see cref="HiddenPassageRevealedEvent"/> を、
+        /// 失敗した場合は <see cref="GimmickActivationFailedEvent"/>（<see cref="GimmickType.HiddenPassage"/>）を発行する
+        /// </summary>
+        /// <param name="roomPosition">ギミックが属する部屋の位置</param>
+        /// <param name="gimmickPosition">発動対象のギミックの位置</param>
+        /// <returns>発動に成功した場合は true</returns>
+        public bool TryActivateHiddenPassage(Vector2I roomPosition, Vector2I gimmickPosition)
+        {
+            if (_gimmickActivator.TryActivateHiddenPassage(Rooms.Value, roomPosition, gimmickPosition))
+            {
+                _navigationManager.BuildMesh(Rooms.Value, _levelGenerationModel.RoomTemplates);
+                EventBus.Publish(new HiddenPassageRevealedEvent(roomPosition, gimmickPosition));
+                return true;
+            }
+
+            EventBus.Publish(new GimmickActivationFailedEvent(roomPosition, gimmickPosition, GimmickType.HiddenPassage));
+            return false;
+        }
+
+        /// <summary>
+        /// 鍵扉ギミックの発動（解錠）を試みる
+        /// 発動に成功した場合はナビゲーションメッシュを再構築したうえで <see cref="LockedDoorUnlockedEvent"/> を、
+        /// 失敗した場合は <see cref="GimmickActivationFailedEvent"/>（<see cref="GimmickType.LockedDoor"/>）を発行する
+        /// </summary>
+        /// <param name="roomPosition">ギミックが属する部屋の位置</param>
+        /// <param name="gimmickPosition">発動対象のギミックの位置</param>
+        /// <param name="hasKey">鍵を所持しているかどうか</param>
+        /// <returns>発動に成功した場合は true</returns>
+        public bool TryActivateLockedDoor(Vector2I roomPosition, Vector2I gimmickPosition, bool hasKey)
+        {
+            if (_gimmickActivator.TryActivateLockedDoor(Rooms.Value, roomPosition, gimmickPosition, hasKey))
+            {
+                _navigationManager.BuildMesh(Rooms.Value, _levelGenerationModel.RoomTemplates);
+                EventBus.Publish(new LockedDoorUnlockedEvent(roomPosition, gimmickPosition));
+                return true;
+            }
+
+            EventBus.Publish(new GimmickActivationFailedEvent(roomPosition, gimmickPosition, GimmickType.LockedDoor));
+            return false;
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/ViewModels/RoomViewModel.cs
+++ b/Scripts/Systems/Dungeon/ViewModels/RoomViewModel.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using Core.Events;
+using Core.Reactive;
+using Core.ViewModels;
+using Systems.Dungeon.Data;
+
+namespace Systems.Dungeon.ViewModels
+{
+    /// <summary>
+    /// 部屋ビューモデル
+    /// 単一の部屋（<see cref="RoomData"/>）の状態を View 層向けに公開する軽量な ViewModel
+    /// 扉・ギミック一覧は、部屋生成後もギミック発動（<see cref="Gimmicks.GimmickActivator"/>）等によって
+    /// <see cref="RoomData"/> 側の要素が in-place で書き換えられるため、キャッシュを持たず
+    /// 都度 <see cref="RoomData"/> を参照するプロパティとして公開する（常に最新の状態を返す）
+    /// </summary>
+    public class RoomViewModel : ViewModelBase
+    {
+        private readonly RoomData _room;
+
+        /// <summary>
+        /// 部屋の種類
+        /// </summary>
+        public ReactiveProperty<RoomType> Type { get; }
+
+        /// <summary>
+        /// 部屋が訪問済みかどうか
+        /// </summary>
+        public ReactiveProperty<bool> IsVisited { get; }
+
+        /// <summary>
+        /// 部屋に属する扉の一覧
+        /// <see cref="RoomData"/> の現在の状態をそのまま返すため、都度最新の内容を反映する
+        /// </summary>
+        public IReadOnlyList<DoorData> Doors => _room.Doors;
+
+        /// <summary>
+        /// 部屋に配置されたギミックの一覧
+        /// <see cref="RoomData"/> の現在の状態をそのまま返すため、都度最新の内容を反映する
+        /// </summary>
+        public IReadOnlyList<GimmickData> Gimmicks => _room.Gimmicks;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="room">表示対象の部屋データ</param>
+        /// <param name="eventBus">イベントバス</param>
+        /// <exception cref="ArgumentNullException">room が null の場合</exception>
+        public RoomViewModel(RoomData room, IGameEventBus eventBus) : base(eventBus)
+        {
+            _room = room ?? throw new ArgumentNullException(nameof(room));
+
+            Type = new ReactiveProperty<RoomType>(_room.Type).AddTo(Disposables);
+            IsVisited = new ReactiveProperty<bool>(false).AddTo(Disposables);
+        }
+
+        /// <summary>
+        /// 部屋を訪問済みとしてマークする
+        /// </summary>
+        public void MarkVisited()
+        {
+            IsVisited.Value = true;
+        }
+    }
+}

--- a/Scripts/Systems/Dungeon/ViewModels/RoomViewModel.cs
+++ b/Scripts/Systems/Dungeon/ViewModels/RoomViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Core.Events;
 using Core.Reactive;
 using Core.ViewModels;
@@ -10,18 +11,19 @@ namespace Systems.Dungeon.ViewModels
     /// <summary>
     /// 部屋ビューモデル
     /// 単一の部屋（<see cref="RoomData"/>）の状態を View 層向けに公開する軽量な ViewModel
+    /// 部屋の種類は生成後に変化しないため単純なプロパティとして公開する。
     /// 扉・ギミック一覧は、部屋生成後もギミック発動（<see cref="Gimmicks.GimmickActivator"/>）等によって
-    /// <see cref="RoomData"/> 側の要素が in-place で書き換えられるため、キャッシュを持たず
-    /// 都度 <see cref="RoomData"/> を参照するプロパティとして公開する（常に最新の状態を返す）
+    /// <see cref="RoomData"/> 側の要素が in-place で書き換えられるため、<see cref="ReactiveProperty{T}"/> でスナップショットを保持し、
+    /// 変更後は <see cref="Refresh"/> を呼び出すことで最新状態への更新と変更通知を行う
     /// </summary>
     public class RoomViewModel : ViewModelBase
     {
         private readonly RoomData _room;
 
         /// <summary>
-        /// 部屋の種類
+        /// 部屋の種類（生成後は変化しない）
         /// </summary>
-        public ReactiveProperty<RoomType> Type { get; }
+        public RoomType Type { get; }
 
         /// <summary>
         /// 部屋が訪問済みかどうか
@@ -29,16 +31,14 @@ namespace Systems.Dungeon.ViewModels
         public ReactiveProperty<bool> IsVisited { get; }
 
         /// <summary>
-        /// 部屋に属する扉の一覧
-        /// <see cref="RoomData"/> の現在の状態をそのまま返すため、都度最新の内容を反映する
+        /// 部屋に属する扉の一覧（<see cref="Refresh"/> 呼び出し時点のスナップショット）
         /// </summary>
-        public IReadOnlyList<DoorData> Doors => _room.Doors;
+        public ReactiveProperty<IReadOnlyList<DoorData>> Doors { get; }
 
         /// <summary>
-        /// 部屋に配置されたギミックの一覧
-        /// <see cref="RoomData"/> の現在の状態をそのまま返すため、都度最新の内容を反映する
+        /// 部屋に配置されたギミックの一覧（<see cref="Refresh"/> 呼び出し時点のスナップショット）
         /// </summary>
-        public IReadOnlyList<GimmickData> Gimmicks => _room.Gimmicks;
+        public ReactiveProperty<IReadOnlyList<GimmickData>> Gimmicks { get; }
 
         /// <summary>
         /// コンストラクタ
@@ -50,8 +50,10 @@ namespace Systems.Dungeon.ViewModels
         {
             _room = room ?? throw new ArgumentNullException(nameof(room));
 
-            Type = new ReactiveProperty<RoomType>(_room.Type).AddTo(Disposables);
+            Type = _room.Type;
             IsVisited = new ReactiveProperty<bool>(false).AddTo(Disposables);
+            Doors = new ReactiveProperty<IReadOnlyList<DoorData>>(_room.Doors.ToList()).AddTo(Disposables);
+            Gimmicks = new ReactiveProperty<IReadOnlyList<GimmickData>>(_room.Gimmicks.ToList()).AddTo(Disposables);
         }
 
         /// <summary>
@@ -60,6 +62,16 @@ namespace Systems.Dungeon.ViewModels
         public void MarkVisited()
         {
             IsVisited.Value = true;
+        }
+
+        /// <summary>
+        /// 扉・ギミックの一覧を <see cref="RoomData"/> の現在の状態から再取得し、変更を通知する
+        /// <see cref="Gimmicks.GimmickActivator"/> 等による <see cref="RoomData"/> の in-place な状態変更後に呼び出す想定
+        /// </summary>
+        public void Refresh()
+        {
+            Doors.Value = _room.Doors.ToList();
+            Gimmicks.Value = _room.Gimmicks.ToList();
         }
     }
 }

--- a/Tests/Core/Dungeon/Gimmicks/GimmickActivatorTests.cs
+++ b/Tests/Core/Dungeon/Gimmicks/GimmickActivatorTests.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Godot;
+using Systems.Dungeon.Data;
+using Systems.Dungeon.Gimmicks;
+
+namespace Tests.Core.Dungeon.Gimmicks
+{
+    public class GimmickActivatorTests
+    {
+        private static readonly Vector2I RoomAPosition = new(0, 0);
+        private static readonly Vector2I RoomBPosition = new(16, 0);
+        private static readonly Vector2I DoorAPosition = new(15, 8);
+        private static readonly Vector2I DoorBPosition = new(16, 8);
+
+        /// <summary>
+        /// 隠し通路ギミックが両側に配置された部屋ペアを作成する
+        /// </summary>
+        private static Dictionary<Vector2I, RoomData> CreateRoomsWithHiddenPassage()
+        {
+            var roomA = new RoomData { Position = RoomAPosition, Type = RoomType.Combat };
+            var roomB = new RoomData { Position = RoomBPosition, Type = RoomType.Secret };
+
+            roomA.AddDoor(new DoorData { Position = DoorAPosition, Type = DoorType.Secret, IsLocked = false, ConnectedRoomPosition = RoomBPosition });
+            roomB.AddDoor(new DoorData { Position = DoorBPosition, Type = DoorType.Secret, IsLocked = false, ConnectedRoomPosition = RoomAPosition });
+
+            roomA.AddGimmick(new GimmickData { Position = DoorAPosition, Type = GimmickType.HiddenPassage, IsActive = false });
+            roomB.AddGimmick(new GimmickData { Position = DoorBPosition, Type = GimmickType.HiddenPassage, IsActive = false });
+
+            return new Dictionary<Vector2I, RoomData> { [RoomAPosition] = roomA, [RoomBPosition] = roomB };
+        }
+
+        /// <summary>
+        /// 鍵扉ギミックが両側に配置された部屋ペアを作成する
+        /// </summary>
+        private static Dictionary<Vector2I, RoomData> CreateRoomsWithLockedDoor()
+        {
+            var roomA = new RoomData { Position = RoomAPosition, Type = RoomType.Combat };
+            var roomB = new RoomData { Position = RoomBPosition, Type = RoomType.Treasure };
+
+            roomA.AddDoor(new DoorData { Position = DoorAPosition, Type = DoorType.Locked, IsLocked = true, ConnectedRoomPosition = RoomBPosition });
+            roomB.AddDoor(new DoorData { Position = DoorBPosition, Type = DoorType.Locked, IsLocked = true, ConnectedRoomPosition = RoomAPosition });
+
+            roomA.AddGimmick(new GimmickData { Position = DoorAPosition, Type = GimmickType.LockedDoor, IsActive = false });
+            roomB.AddGimmick(new GimmickData { Position = DoorBPosition, Type = GimmickType.LockedDoor, IsActive = false });
+
+            return new Dictionary<Vector2I, RoomData> { [RoomAPosition] = roomA, [RoomBPosition] = roomB };
+        }
+
+        [Test]
+        public void TryActivateHiddenPassage_ValidGimmick_ActivatesBothSidesAndOpensDoors()
+        {
+            var rooms = CreateRoomsWithHiddenPassage();
+            var activator = new GimmickActivator();
+
+            bool result = activator.TryActivateHiddenPassage(rooms, RoomAPosition, DoorAPosition);
+
+            Assert.IsTrue(result);
+
+            // 発動した側・接続先の両方のギミックが有効化されること
+            Assert.IsTrue(rooms[RoomAPosition].Gimmicks.Single().IsActive);
+            Assert.IsTrue(rooms[RoomBPosition].Gimmicks.Single().IsActive);
+
+            // 発動した側・接続先の両方の扉が通常の扉に変わること
+            Assert.AreEqual(DoorType.Normal, rooms[RoomAPosition].Doors.Single().Type);
+            Assert.AreEqual(DoorType.Normal, rooms[RoomBPosition].Doors.Single().Type);
+        }
+
+        [Test]
+        public void TryActivateHiddenPassage_AlreadyActive_ReturnsFalseAndDoesNotChangeState()
+        {
+            var rooms = CreateRoomsWithHiddenPassage();
+            var activator = new GimmickActivator();
+            Assert.IsTrue(activator.TryActivateHiddenPassage(rooms, RoomAPosition, DoorAPosition));
+
+            // 二重発動は失敗すること
+            bool result = activator.TryActivateHiddenPassage(rooms, RoomAPosition, DoorAPosition);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void TryActivateHiddenPassage_GimmickNotFound_ReturnsFalse()
+        {
+            var rooms = CreateRoomsWithHiddenPassage();
+            var activator = new GimmickActivator();
+
+            // 存在しない位置を指定した場合は失敗すること
+            bool result = activator.TryActivateHiddenPassage(rooms, RoomAPosition, new Vector2I(99, 99));
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void TryActivateHiddenPassage_WrongGimmickType_ReturnsFalse()
+        {
+            var rooms = CreateRoomsWithLockedDoor();
+            var activator = new GimmickActivator();
+
+            // 鍵扉ギミックを隠し通路として発動しようとすると失敗すること
+            bool result = activator.TryActivateHiddenPassage(rooms, RoomAPosition, DoorAPosition);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void TryActivateLockedDoor_NoKey_ReturnsFalse()
+        {
+            var rooms = CreateRoomsWithLockedDoor();
+            var activator = new GimmickActivator();
+
+            // 鍵を所持していない場合は常に失敗すること
+            bool result = activator.TryActivateLockedDoor(rooms, RoomAPosition, DoorAPosition, hasKey: false);
+
+            Assert.IsFalse(result);
+            Assert.IsFalse(rooms[RoomAPosition].Gimmicks.Single().IsActive);
+            Assert.IsTrue(rooms[RoomAPosition].Doors.Single().IsLocked);
+        }
+
+        [Test]
+        public void TryActivateLockedDoor_HasKey_ActivatesBothSidesAndUnlocksDoors()
+        {
+            var rooms = CreateRoomsWithLockedDoor();
+            var activator = new GimmickActivator();
+
+            bool result = activator.TryActivateLockedDoor(rooms, RoomAPosition, DoorAPosition, hasKey: true);
+
+            Assert.IsTrue(result);
+
+            // 発動した側・接続先の両方のギミックが有効化されること
+            Assert.IsTrue(rooms[RoomAPosition].Gimmicks.Single().IsActive);
+            Assert.IsTrue(rooms[RoomBPosition].Gimmicks.Single().IsActive);
+
+            // 両側の扉が解錠されること（種類は Locked のまま据え置き）
+            Assert.IsFalse(rooms[RoomAPosition].Doors.Single().IsLocked);
+            Assert.IsFalse(rooms[RoomBPosition].Doors.Single().IsLocked);
+            Assert.AreEqual(DoorType.Locked, rooms[RoomAPosition].Doors.Single().Type);
+            Assert.AreEqual(DoorType.Locked, rooms[RoomBPosition].Doors.Single().Type);
+        }
+
+        [Test]
+        public void TryActivateLockedDoor_AlreadyActive_ReturnsFalse()
+        {
+            var rooms = CreateRoomsWithLockedDoor();
+            var activator = new GimmickActivator();
+            Assert.IsTrue(activator.TryActivateLockedDoor(rooms, RoomAPosition, DoorAPosition, hasKey: true));
+
+            // 二重発動は失敗すること
+            bool result = activator.TryActivateLockedDoor(rooms, RoomAPosition, DoorAPosition, hasKey: true);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void TryActivateLockedDoor_GimmickNotFound_ReturnsFalse()
+        {
+            var rooms = CreateRoomsWithLockedDoor();
+            var activator = new GimmickActivator();
+
+            // 存在しない位置を指定した場合は失敗すること
+            bool result = activator.TryActivateLockedDoor(rooms, RoomAPosition, new Vector2I(99, 99), hasKey: true);
+
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/Tests/Core/Dungeon/Gimmicks/GimmickActivatorTests.cs
+++ b/Tests/Core/Dungeon/Gimmicks/GimmickActivatorTests.cs
@@ -105,6 +105,21 @@ namespace Tests.Core.Dungeon.Gimmicks
         }
 
         [Test]
+        public void TryActivateHiddenPassage_ConnectedRoomMissing_ReturnsFalseAndDoesNotChangeLocalState()
+        {
+            var rooms = CreateRoomsWithHiddenPassage();
+            rooms.Remove(RoomBPosition);
+            var activator = new GimmickActivator();
+
+            // 接続先の部屋が見つからない場合、自室側の状態も変更せずに失敗すること（片側だけの発動を防ぐ）
+            bool result = activator.TryActivateHiddenPassage(rooms, RoomAPosition, DoorAPosition);
+
+            Assert.IsFalse(result);
+            Assert.IsFalse(rooms[RoomAPosition].Gimmicks.Single().IsActive);
+            Assert.AreEqual(DoorType.Secret, rooms[RoomAPosition].Doors.Single().Type);
+        }
+
+        [Test]
         public void TryActivateLockedDoor_NoKey_ReturnsFalse()
         {
             var rooms = CreateRoomsWithLockedDoor();
@@ -162,6 +177,21 @@ namespace Tests.Core.Dungeon.Gimmicks
             bool result = activator.TryActivateLockedDoor(rooms, RoomAPosition, new Vector2I(99, 99), hasKey: true);
 
             Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void TryActivateLockedDoor_ConnectedRoomMissing_ReturnsFalseAndDoesNotChangeLocalState()
+        {
+            var rooms = CreateRoomsWithLockedDoor();
+            rooms.Remove(RoomBPosition);
+            var activator = new GimmickActivator();
+
+            // 接続先の部屋が見つからない場合、自室側の状態も変更せずに失敗すること（片側だけの解錠を防ぐ）
+            bool result = activator.TryActivateLockedDoor(rooms, RoomAPosition, DoorAPosition, hasKey: true);
+
+            Assert.IsFalse(result);
+            Assert.IsFalse(rooms[RoomAPosition].Gimmicks.Single().IsActive);
+            Assert.IsTrue(rooms[RoomAPosition].Doors.Single().IsLocked);
         }
     }
 }

--- a/Tests/Core/Dungeon/Gimmicks/GimmickPlacementModelTests.cs
+++ b/Tests/Core/Dungeon/Gimmicks/GimmickPlacementModelTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Godot;
+using Systems.Dungeon.Data;
+using Systems.Dungeon.Gimmicks;
+using Systems.Dungeon.Models;
+
+namespace Tests.Core.Dungeon.Gimmicks
+{
+    public class GimmickPlacementModelTests
+    {
+        /// <summary>
+        /// 性質ベーステストで使用するシード数
+        /// </summary>
+        private const int SEED_COUNT = 10;
+
+        /// <summary>
+        /// 部屋 A・B を扉で接続した最小限の部屋辞書を作成する
+        /// </summary>
+        private static Dictionary<Vector2I, RoomData> CreateConnectedRoomPair(
+            Vector2I positionA, RoomType typeA, Vector2I doorPositionA,
+            Vector2I positionB, RoomType typeB, Vector2I doorPositionB)
+        {
+            var roomA = new RoomData { Position = positionA, Type = typeA };
+            var roomB = new RoomData { Position = positionB, Type = typeB };
+
+            roomA.AddDoor(new DoorData
+            {
+                Position = doorPositionA,
+                Type = DoorType.Normal,
+                IsLocked = false,
+                ConnectedRoomPosition = positionB
+            });
+            roomB.AddDoor(new DoorData
+            {
+                Position = doorPositionB,
+                Type = DoorType.Normal,
+                IsLocked = false,
+                ConnectedRoomPosition = positionA
+            });
+
+            return new Dictionary<Vector2I, RoomData> { [positionA] = roomA, [positionB] = roomB };
+        }
+
+        [Test]
+        public void Constructor_NullRandom_ThrowsArgumentNullException()
+        {
+            // 乱数の注入が必須であること
+            Assert.Throws<ArgumentNullException>(() => _ = new GimmickPlacementModel(null!));
+        }
+
+        [Test]
+        public void PlaceGimmicks_NullRooms_ThrowsArgumentNullException()
+        {
+            var model = new GimmickPlacementModel(new Random(0));
+
+            Assert.Throws<ArgumentNullException>(() => model.PlaceGimmicks(null!));
+        }
+
+        [Test]
+        public void PlaceGimmicks_SecretRoomDoor_BecomesHiddenPassageOnBothSides()
+        {
+            var positionA = new Vector2I(0, 0);
+            var positionB = new Vector2I(16, 0);
+            var doorA = new Vector2I(15, 8);
+            var doorB = new Vector2I(16, 8);
+            var rooms = CreateConnectedRoomPair(positionA, RoomType.Combat, doorA, positionB, RoomType.Secret, doorB);
+
+            new GimmickPlacementModel(new Random(0)).PlaceGimmicks(rooms);
+
+            // 両側の扉が隠し扉（Secret）に変わり、施錠はされていないこと
+            Assert.AreEqual(DoorType.Secret, rooms[positionA].Doors[0].Type);
+            Assert.IsFalse(rooms[positionA].Doors[0].IsLocked);
+            Assert.AreEqual(DoorType.Secret, rooms[positionB].Doors[0].Type);
+            Assert.IsFalse(rooms[positionB].Doors[0].IsLocked);
+
+            // 両側の部屋に未発動の隠し通路ギミックが追加されていること
+            var gimmickA = rooms[positionA].Gimmicks.Single();
+            Assert.AreEqual(GimmickType.HiddenPassage, gimmickA.Type);
+            Assert.AreEqual(doorA, gimmickA.Position);
+            Assert.IsFalse(gimmickA.IsActive);
+
+            var gimmickB = rooms[positionB].Gimmicks.Single();
+            Assert.AreEqual(GimmickType.HiddenPassage, gimmickB.Type);
+            Assert.AreEqual(doorB, gimmickB.Position);
+            Assert.IsFalse(gimmickB.IsActive);
+        }
+
+        [Test]
+        public void PlaceGimmicks_TreasureDoorNotAdjacentToStart_BecomesLockedDoor()
+        {
+            // Start - Combat - Treasure の一直線構成（Combat-Treasure の扉のみが候補になる）
+            var start = new Vector2I(0, 0);
+            var combat = new Vector2I(16, 0);
+            var treasure = new Vector2I(32, 0);
+
+            var rooms = CreateConnectedRoomPair(start, RoomType.Start, new Vector2I(15, 8), combat, RoomType.Combat, new Vector2I(16, 8));
+            var combatTreasureDoorCombat = new Vector2I(31, 8);
+            var combatTreasureDoorTreasure = new Vector2I(32, 8);
+            rooms[combat].AddDoor(new DoorData
+            {
+                Position = combatTreasureDoorCombat,
+                Type = DoorType.Normal,
+                IsLocked = false,
+                ConnectedRoomPosition = treasure
+            });
+            rooms[treasure] = new RoomData { Position = treasure, Type = RoomType.Treasure };
+            rooms[treasure].AddDoor(new DoorData
+            {
+                Position = combatTreasureDoorTreasure,
+                Type = DoorType.Normal,
+                IsLocked = false,
+                ConnectedRoomPosition = combat
+            });
+
+            new GimmickPlacementModel(new Random(0)).PlaceGimmicks(rooms);
+
+            // Start-Combat の扉は変更されないこと
+            var startDoor = rooms[start].Doors.Single();
+            Assert.AreEqual(DoorType.Normal, startDoor.Type);
+            Assert.IsFalse(startDoor.IsLocked);
+            Assert.IsEmpty(rooms[start].Gimmicks);
+
+            // Combat-Treasure の扉が鍵扉になること
+            var combatDoorToTreasure = rooms[combat].Doors.Single(d => d.ConnectedRoomPosition == treasure);
+            Assert.AreEqual(DoorType.Locked, combatDoorToTreasure.Type);
+            Assert.IsTrue(combatDoorToTreasure.IsLocked);
+
+            var treasureDoor = rooms[treasure].Doors.Single();
+            Assert.AreEqual(DoorType.Locked, treasureDoor.Type);
+            Assert.IsTrue(treasureDoor.IsLocked);
+
+            // 両側の部屋に未発動の鍵扉ギミックが追加されていること
+            var combatGimmick = rooms[combat].Gimmicks.Single();
+            Assert.AreEqual(GimmickType.LockedDoor, combatGimmick.Type);
+            Assert.AreEqual(combatTreasureDoorCombat, combatGimmick.Position);
+            Assert.IsFalse(combatGimmick.IsActive);
+
+            var treasureGimmick = rooms[treasure].Gimmicks.Single();
+            Assert.AreEqual(GimmickType.LockedDoor, treasureGimmick.Type);
+            Assert.AreEqual(combatTreasureDoorTreasure, treasureGimmick.Position);
+            Assert.IsFalse(treasureGimmick.IsActive);
+        }
+
+        [Test]
+        public void PlaceGimmicks_TreasureAdjacentToStart_NoLockedDoorPlaced()
+        {
+            // Start に直接隣接する Treasure しか存在しない場合、候補が 0 件になり鍵扉は配置されない
+            var start = new Vector2I(0, 0);
+            var treasure = new Vector2I(16, 0);
+            var rooms = CreateConnectedRoomPair(start, RoomType.Start, new Vector2I(15, 8), treasure, RoomType.Treasure, new Vector2I(16, 8));
+
+            new GimmickPlacementModel(new Random(0)).PlaceGimmicks(rooms);
+
+            Assert.AreEqual(DoorType.Normal, rooms[start].Doors[0].Type);
+            Assert.AreEqual(DoorType.Normal, rooms[treasure].Doors[0].Type);
+            Assert.IsEmpty(rooms[start].Gimmicks);
+            Assert.IsEmpty(rooms[treasure].Gimmicks);
+        }
+
+        [Test]
+        public async Task PlaceGimmicks_MultipleSeeds_AllSecretRoomDoorsBecomeHiddenPassage()
+        {
+            // 複数シードで生成した実際のレベルに対し、Secret 部屋の全扉が隠し通路化されること
+            for (int seed = 0; seed < SEED_COUNT; seed++)
+            {
+                var levelModel = new LevelGenerationModel(seed);
+                var rooms = await levelModel.GenerateLevelAsync();
+
+                new GimmickPlacementModel(new Random(seed)).PlaceGimmicks(rooms);
+
+                foreach (var room in rooms.Values.Where(r => r.Type == RoomType.Secret))
+                {
+                    foreach (var door in room.Doors)
+                    {
+                        Assert.AreEqual(DoorType.Secret, door.Type, $"シード {seed}: Secret 部屋の扉が隠し扉化されていない");
+                        Assert.IsFalse(door.IsLocked, $"シード {seed}: 隠し扉が施錠されている");
+
+                        var connectedRoom = rooms[door.ConnectedRoomPosition];
+                        var connectedDoor = connectedRoom.Doors.Single(d => d.ConnectedRoomPosition == room.Position);
+                        Assert.AreEqual(DoorType.Secret, connectedDoor.Type, $"シード {seed}: 接続先の扉が隠し扉化されていない");
+
+                        Assert.IsTrue(room.Gimmicks.Any(g => g.Type == GimmickType.HiddenPassage && g.Position == door.Position && !g.IsActive),
+                            $"シード {seed}: Secret 側に隠し通路ギミックがない");
+                        Assert.IsTrue(connectedRoom.Gimmicks.Any(g => g.Type == GimmickType.HiddenPassage && g.Position == connectedDoor.Position && !g.IsActive),
+                            $"シード {seed}: 接続先に隠し通路ギミックがない");
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public async Task PlaceGimmicks_MultipleSeeds_LockedDoorInvariantsHold()
+        {
+            // 複数シードで、鍵扉は 0 個か対になる 2 個のみ存在し、Start に隣接せず Treasure/Boss に接続すること
+            for (int seed = 0; seed < SEED_COUNT; seed++)
+            {
+                var levelModel = new LevelGenerationModel(seed);
+                var rooms = await levelModel.GenerateLevelAsync();
+
+                new GimmickPlacementModel(new Random(seed)).PlaceGimmicks(rooms);
+
+                var lockedDoors = rooms.Values.SelectMany(r => r.Doors.Select(d => (Room: r, Door: d)))
+                    .Where(x => x.Door.Type == DoorType.Locked)
+                    .ToList();
+
+                Assert.That(lockedDoors.Count, Is.EqualTo(0).Or.EqualTo(2), $"シード {seed}: 鍵扉の数が 0 または 2 でない");
+
+                foreach (var (room, door) in lockedDoors)
+                {
+                    Assert.IsTrue(door.IsLocked, $"シード {seed}: 鍵扉が施錠されていない");
+                    Assert.AreNotEqual(RoomType.Start, room.Type, $"シード {seed}: Start 部屋の扉が鍵扉化された");
+
+                    var connectedRoom = rooms[door.ConnectedRoomPosition];
+                    Assert.AreNotEqual(RoomType.Start, connectedRoom.Type, $"シード {seed}: Start に隣接する扉が鍵扉化された");
+                    Assert.IsTrue(room.Type is RoomType.Treasure or RoomType.Boss || connectedRoom.Type is RoomType.Treasure or RoomType.Boss,
+                        $"シード {seed}: Treasure/Boss に接続しない扉が鍵扉化された");
+
+                    Assert.IsTrue(room.Gimmicks.Any(g => g.Type == GimmickType.LockedDoor && g.Position == door.Position && !g.IsActive),
+                        $"シード {seed}: 鍵扉ギミックが追加されていない");
+                }
+            }
+        }
+    }
+}

--- a/Tests/Core/Dungeon/Navigation/NavigationManagerTests.cs
+++ b/Tests/Core/Dungeon/Navigation/NavigationManagerTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Godot;
+using Systems.Dungeon.Data;
+using Systems.Dungeon.Gimmicks;
+using Systems.Dungeon.Models;
+using Systems.Dungeon.Navigation;
+
+namespace Tests.Core.Dungeon.Navigation
+{
+    public class NavigationManagerTests
+    {
+        private static readonly Vector2I RoomAPosition = new(0, 0);
+        private static readonly Vector2I RoomBPosition = new(16, 0);
+        private static readonly Vector2I DoorAPosition = new(15, 8);
+        private static readonly Vector2I DoorBPosition = new(16, 8);
+
+        /// <summary>
+        /// 鍵扉ギミック付きで接続された 2 部屋（部屋テンプレート付き）を作成する
+        /// </summary>
+        private static (Dictionary<Vector2I, RoomData> Rooms, Dictionary<Vector2I, RoomTemplate> Templates) CreateRoomsWithLockedDoor()
+        {
+            var roomA = new RoomData { Position = RoomAPosition, Type = RoomType.Combat };
+            var roomB = new RoomData { Position = RoomBPosition, Type = RoomType.Treasure };
+
+            roomA.AddDoor(new DoorData { Position = DoorAPosition, Type = DoorType.Locked, IsLocked = true, ConnectedRoomPosition = RoomBPosition });
+            roomB.AddDoor(new DoorData { Position = DoorBPosition, Type = DoorType.Locked, IsLocked = true, ConnectedRoomPosition = RoomAPosition });
+
+            roomA.AddGimmick(new GimmickData { Position = DoorAPosition, Type = GimmickType.LockedDoor, IsActive = false });
+            roomB.AddGimmick(new GimmickData { Position = DoorBPosition, Type = GimmickType.LockedDoor, IsActive = false });
+
+            var rooms = new Dictionary<Vector2I, RoomData> { [RoomAPosition] = roomA, [RoomBPosition] = roomB };
+            var templates = new Dictionary<Vector2I, RoomTemplate>
+            {
+                [RoomAPosition] = new RoomTemplate { Type = RoomType.Combat },
+                [RoomBPosition] = new RoomTemplate { Type = RoomType.Treasure }
+            };
+
+            return (rooms, templates);
+        }
+
+        [Test]
+        public void FindPath_AcrossConnectedRooms_ReturnsPathThroughDoor()
+        {
+            var roomA = new RoomData { Position = RoomAPosition, Type = RoomType.Combat };
+            var roomB = new RoomData { Position = RoomBPosition, Type = RoomType.Combat };
+            roomA.AddDoor(new DoorData { Position = DoorAPosition, Type = DoorType.Normal, IsLocked = false, ConnectedRoomPosition = RoomBPosition });
+            roomB.AddDoor(new DoorData { Position = DoorBPosition, Type = DoorType.Normal, IsLocked = false, ConnectedRoomPosition = RoomAPosition });
+
+            var rooms = new Dictionary<Vector2I, RoomData> { [RoomAPosition] = roomA, [RoomBPosition] = roomB };
+            var templates = new Dictionary<Vector2I, RoomTemplate>
+            {
+                [RoomAPosition] = new RoomTemplate { Type = RoomType.Combat },
+                [RoomBPosition] = new RoomTemplate { Type = RoomType.Combat }
+            };
+
+            var manager = new NavigationManager();
+            manager.BuildMesh(rooms, templates);
+
+            var start = RoomAPosition + new Vector2I(1, 1);
+            var goal = RoomBPosition + new Vector2I(1, 1);
+            var path = manager.FindPath(start, goal);
+
+            Assert.IsNotEmpty(path);
+            Assert.AreEqual(start, path[0]);
+            Assert.AreEqual(goal, path[^1]);
+            Assert.Contains(DoorAPosition, path);
+            Assert.Contains(DoorBPosition, path);
+        }
+
+        [Test]
+        public void BuildMesh_AfterLockedDoorGimmickActivated_PathBecomesAvailable()
+        {
+            var (rooms, templates) = CreateRoomsWithLockedDoor();
+            var manager = new NavigationManager();
+            manager.BuildMesh(rooms, templates);
+
+            var start = RoomAPosition + new Vector2I(1, 1);
+            var goal = RoomBPosition + new Vector2I(1, 1);
+
+            // 施錠されている間は経路が存在しないこと
+            Assert.IsEmpty(manager.FindPath(start, goal));
+
+            // 鍵扉ギミックを発動（解錠）した後、メッシュを再構築すると経路が通ること
+            var activator = new GimmickActivator();
+            bool activated = activator.TryActivateLockedDoor(rooms, RoomAPosition, DoorAPosition, hasKey: true);
+            Assert.IsTrue(activated);
+
+            manager.BuildMesh(rooms, templates);
+            var pathAfterUnlock = manager.FindPath(start, goal);
+
+            Assert.IsNotEmpty(pathAfterUnlock);
+            Assert.AreEqual(start, pathAfterUnlock[0]);
+            Assert.AreEqual(goal, pathAfterUnlock[^1]);
+        }
+    }
+}

--- a/Tests/Core/Dungeon/Navigation/NavigationMeshTests.cs
+++ b/Tests/Core/Dungeon/Navigation/NavigationMeshTests.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Godot;
+using Systems.Dungeon.Data;
+using Systems.Dungeon.Models;
+using NavigationMesh = Systems.Dungeon.Navigation.NavigationMesh;
+
+namespace Tests.Core.Dungeon.Navigation
+{
+    public class NavigationMeshTests
+    {
+        private static readonly Vector2I RoomAPosition = new(0, 0);
+        private static readonly Vector2I RoomBPosition = new(16, 0);
+        private static readonly Vector2I DoorAPosition = new(15, 8);
+        private static readonly Vector2I DoorBPosition = new(16, 8);
+
+        /// <summary>
+        /// 扉で接続された 2 部屋（部屋テンプレート付き）を作成する
+        /// </summary>
+        private static (Dictionary<Vector2I, RoomData> Rooms, Dictionary<Vector2I, RoomTemplate> Templates) CreateConnectedRoomPair(
+            DoorType doorType, bool isLocked, List<Vector2I>? obstaclesA = null)
+        {
+            var roomA = new RoomData { Position = RoomAPosition, Type = RoomType.Combat };
+            var roomB = new RoomData { Position = RoomBPosition, Type = RoomType.Combat };
+
+            roomA.AddDoor(new DoorData { Position = DoorAPosition, Type = doorType, IsLocked = isLocked, ConnectedRoomPosition = RoomBPosition });
+            roomB.AddDoor(new DoorData { Position = DoorBPosition, Type = doorType, IsLocked = isLocked, ConnectedRoomPosition = RoomAPosition });
+
+            var rooms = new Dictionary<Vector2I, RoomData> { [RoomAPosition] = roomA, [RoomBPosition] = roomB };
+            var templates = new Dictionary<Vector2I, RoomTemplate>
+            {
+                [RoomAPosition] = new RoomTemplate { Type = RoomType.Combat, ObstaclePositions = obstaclesA ?? new List<Vector2I>() },
+                [RoomBPosition] = new RoomTemplate { Type = RoomType.Combat, ObstaclePositions = new List<Vector2I>() }
+            };
+
+            return (rooms, templates);
+        }
+
+        [Test]
+        public void Build_RoomInterior_IsWalkableExceptObstacles()
+        {
+            var obstacle = new Vector2I(5, 5);
+            var (rooms, templates) = CreateConnectedRoomPair(DoorType.Normal, isLocked: false, obstaclesA: new List<Vector2I> { obstacle });
+
+            var mesh = new NavigationMesh();
+            mesh.Build(rooms, templates);
+
+            // 内部領域（障害物以外）は通行可能であること
+            Assert.IsTrue(mesh.IsWalkable(RoomAPosition + new Vector2I(1, 1)));
+            Assert.IsTrue(mesh.IsWalkable(RoomAPosition + new Vector2I(14, 14)));
+
+            // 障害物の位置は通行不可であること
+            Assert.IsFalse(mesh.IsWalkable(RoomAPosition + obstacle));
+
+            // 外周（壁）は通行不可であること
+            Assert.IsFalse(mesh.IsWalkable(RoomAPosition + new Vector2I(0, 0)));
+        }
+
+        [Test]
+        public void Build_NormalDoor_IsWalkable()
+        {
+            var (rooms, templates) = CreateConnectedRoomPair(DoorType.Normal, isLocked: false);
+
+            var mesh = new NavigationMesh();
+            mesh.Build(rooms, templates);
+
+            Assert.IsTrue(mesh.IsWalkable(DoorAPosition));
+            Assert.IsTrue(mesh.IsWalkable(DoorBPosition));
+        }
+
+        [Test]
+        public void Build_LockedDoor_IsNotWalkable()
+        {
+            var (rooms, templates) = CreateConnectedRoomPair(DoorType.Locked, isLocked: true);
+
+            var mesh = new NavigationMesh();
+            mesh.Build(rooms, templates);
+
+            Assert.IsFalse(mesh.IsWalkable(DoorAPosition));
+            Assert.IsFalse(mesh.IsWalkable(DoorBPosition));
+        }
+
+        [Test]
+        public void Build_UndiscoveredSecretDoor_IsNotWalkable()
+        {
+            var (rooms, templates) = CreateConnectedRoomPair(DoorType.Secret, isLocked: false);
+
+            var mesh = new NavigationMesh();
+            mesh.Build(rooms, templates);
+
+            Assert.IsFalse(mesh.IsWalkable(DoorAPosition));
+            Assert.IsFalse(mesh.IsWalkable(DoorBPosition));
+        }
+
+        [Test]
+        public void Build_CalledAgainAfterDoorStateChanges_ReflectsNewState()
+        {
+            // 鍵扉が解錠された（ギミック発動を模した）状態変化後、再度 Build すると通行可能になること
+            var (rooms, templates) = CreateConnectedRoomPair(DoorType.Locked, isLocked: true);
+            var mesh = new NavigationMesh();
+            mesh.Build(rooms, templates);
+            Assert.IsFalse(mesh.IsWalkable(DoorAPosition));
+
+            rooms[RoomAPosition].Doors[0].IsLocked = false;
+            rooms[RoomBPosition].Doors[0].IsLocked = false;
+            mesh.Build(rooms, templates);
+
+            Assert.IsTrue(mesh.IsWalkable(DoorAPosition));
+            Assert.IsTrue(mesh.IsWalkable(DoorBPosition));
+        }
+
+        [Test]
+        public void GetWalkableNeighbors_ReturnsOnlyOrthogonalWalkableTiles()
+        {
+            var (rooms, templates) = CreateConnectedRoomPair(DoorType.Normal, isLocked: false, obstaclesA: new List<Vector2I> { new(2, 1) });
+
+            var mesh = new NavigationMesh();
+            mesh.Build(rooms, templates);
+
+            var center = RoomAPosition + new Vector2I(1, 1);
+            var neighbors = mesh.GetWalkableNeighbors(center).ToList();
+
+            // 上方向（障害物）は含まれず、右・下は通行可能なので含まれること。斜めは含まれないこと
+            Assert.IsFalse(neighbors.Contains(RoomAPosition + new Vector2I(2, 1)));
+            Assert.IsTrue(neighbors.Contains(RoomAPosition + new Vector2I(1, 2)));
+            CollectionAssert.DoesNotContain(neighbors, RoomAPosition + new Vector2I(2, 2));
+        }
+    }
+}

--- a/Tests/Core/Dungeon/Navigation/PathFinderTests.cs
+++ b/Tests/Core/Dungeon/Navigation/PathFinderTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Godot;
+using Systems.Dungeon.Data;
+using Systems.Dungeon.Models;
+using Systems.Dungeon.Navigation;
+using NavigationMesh = Systems.Dungeon.Navigation.NavigationMesh;
+
+namespace Tests.Core.Dungeon.Navigation
+{
+    public class PathFinderTests
+    {
+        private static readonly Vector2I RoomPosition = new(0, 0);
+
+        /// <summary>
+        /// 指定した障害物を持つ単一の部屋（扉なし）のナビゲーションメッシュを作成する
+        /// </summary>
+        private static NavigationMesh CreateSingleRoomMesh(List<Vector2I> obstacles)
+        {
+            var room = new RoomData { Position = RoomPosition, Type = RoomType.Combat };
+            var rooms = new Dictionary<Vector2I, RoomData> { [RoomPosition] = room };
+            var templates = new Dictionary<Vector2I, RoomTemplate>
+            {
+                [RoomPosition] = new RoomTemplate { Type = RoomType.Combat, ObstaclePositions = obstacles }
+            };
+
+            var mesh = new NavigationMesh();
+            mesh.Build(rooms, templates);
+            return mesh;
+        }
+
+        [Test]
+        public void Constructor_NullMesh_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _ = new PathFinder(null!));
+        }
+
+        [Test]
+        public void FindPath_StartEqualsGoal_ReturnsSingleElementList()
+        {
+            var mesh = CreateSingleRoomMesh(new List<Vector2I>());
+            var pathFinder = new PathFinder(mesh);
+            var point = RoomPosition + new Vector2I(3, 3);
+
+            var path = pathFinder.FindPath(point, point);
+
+            Assert.AreEqual(new List<Vector2I> { point }, path);
+        }
+
+        [Test]
+        public void FindPath_StartNotWalkable_ReturnsEmptyList()
+        {
+            var mesh = CreateSingleRoomMesh(new List<Vector2I>());
+            var pathFinder = new PathFinder(mesh);
+
+            // 壁（外周）は通行不可なので開始地点として無効
+            var path = pathFinder.FindPath(RoomPosition, RoomPosition + new Vector2I(3, 3));
+
+            Assert.IsEmpty(path);
+        }
+
+        [Test]
+        public void FindPath_StraightLine_ReturnsDirectPath()
+        {
+            var mesh = CreateSingleRoomMesh(new List<Vector2I>());
+            var pathFinder = new PathFinder(mesh);
+            var start = RoomPosition + new Vector2I(1, 1);
+            var goal = RoomPosition + new Vector2I(1, 5);
+
+            var path = pathFinder.FindPath(start, goal);
+
+            // 障害物がない直線区間では、マンハッタン距離と同じ長さの最短経路になること
+            Assert.AreEqual(start, path[0]);
+            Assert.AreEqual(goal, path[^1]);
+            Assert.AreEqual(5, path.Count);
+        }
+
+        [Test]
+        public void FindPath_ObstacleWithGap_DetoursThroughGap()
+        {
+            // y = 5 の行を x = 1..13 まで障害物で塞ぎ、x = 14 のみ通行可能な隙間を作る
+            var obstacles = new List<Vector2I>();
+            for (int x = 1; x <= 13; x++)
+            {
+                obstacles.Add(new Vector2I(x, 5));
+            }
+
+            var mesh = CreateSingleRoomMesh(obstacles);
+            var pathFinder = new PathFinder(mesh);
+            var start = RoomPosition + new Vector2I(1, 1);
+            var goal = RoomPosition + new Vector2I(1, 9);
+
+            var path = pathFinder.FindPath(start, goal);
+
+            Assert.IsNotEmpty(path);
+            Assert.AreEqual(start, path[0]);
+            Assert.AreEqual(goal, path[^1]);
+
+            // 経路は隙間（x = 14, y = 5）を通ること
+            Assert.Contains(RoomPosition + new Vector2I(14, 5), path);
+
+            // 障害物の上は通らないこと
+            foreach (var obstacle in obstacles)
+            {
+                Assert.IsFalse(path.Contains(RoomPosition + obstacle));
+            }
+        }
+
+        [Test]
+        public void FindPath_NoPathExists_ReturnsEmptyList()
+        {
+            // y = 5 の行を全幅（x = 1..14）塞ぎ、隙間なしの壁にする
+            var obstacles = new List<Vector2I>();
+            for (int x = 1; x <= 14; x++)
+            {
+                obstacles.Add(new Vector2I(x, 5));
+            }
+
+            var mesh = CreateSingleRoomMesh(obstacles);
+            var pathFinder = new PathFinder(mesh);
+            var start = RoomPosition + new Vector2I(1, 1);
+            var goal = RoomPosition + new Vector2I(1, 9);
+
+            var path = pathFinder.FindPath(start, goal);
+
+            Assert.IsEmpty(path);
+        }
+    }
+}

--- a/Tests/Core/Dungeon/TileMap/RoomTileGeneratorTests.cs
+++ b/Tests/Core/Dungeon/TileMap/RoomTileGeneratorTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Godot;
+using Systems.Dungeon.Data;
+using Systems.Dungeon.Models;
+using Systems.Dungeon.TileMap;
+using Systems.Dungeon.Utilities;
+using TileType = Systems.Dungeon.TileMap.TileType;
+
+namespace Tests.Core.Dungeon.TileMap
+{
+    public class RoomTileGeneratorTests
+    {
+        private static readonly Vector2I RoomPosition = new(32, 16);
+
+        /// <summary>
+        /// 扉を 1 つ持つ部屋データと、対応する部屋テンプレートを作成する
+        /// </summary>
+        private static (RoomData Room, RoomTemplate Template) CreateRoomWithDoor(
+            DoorType doorType, bool isLocked, Vector2I doorLocal, List<Vector2I>? obstacles = null)
+        {
+            var room = new RoomData { Position = RoomPosition, Type = RoomType.Combat };
+            room.AddDoor(new DoorData
+            {
+                Position = RoomPosition + doorLocal,
+                Type = doorType,
+                IsLocked = isLocked,
+                ConnectedRoomPosition = RoomPosition + new Vector2I(16, 0)
+            });
+
+            var template = new RoomTemplate
+            {
+                Type = RoomType.Combat,
+                ObstaclePositions = obstacles ?? new List<Vector2I>(),
+                DoorPositions = new List<Vector2I> { doorLocal }
+            };
+
+            return (room, template);
+        }
+
+        private static TileType FindType(List<(Vector2I WorldPosition, TileType Type)> tiles, Vector2I worldPosition)
+        {
+            return tiles.First(t => t.WorldPosition == worldPosition).Type;
+        }
+
+        [Test]
+        public void GenerateTiles_NullRoom_Throws()
+        {
+            var generator = new RoomTileGenerator();
+            var template = new RoomTemplate();
+
+            Assert.Throws<ArgumentNullException>(() => generator.GenerateTiles(null!, template));
+        }
+
+        [Test]
+        public void GenerateTiles_NullTemplate_Throws()
+        {
+            var generator = new RoomTileGenerator();
+            var room = new RoomData { Position = RoomPosition, Type = RoomType.Combat };
+
+            Assert.Throws<ArgumentNullException>(() => generator.GenerateTiles(room, null!));
+        }
+
+        [Test]
+        public void GenerateTiles_ReturnsAllCellsInRoom()
+        {
+            var (room, template) = CreateRoomWithDoor(DoorType.Normal, isLocked: false, doorLocal: new Vector2I(15, 8));
+            var generator = new RoomTileGenerator();
+
+            var tiles = generator.GenerateTiles(room, template);
+
+            Assert.AreEqual(DungeonConstants.ROOM_SIZE * DungeonConstants.ROOM_SIZE, tiles.Count);
+        }
+
+        [Test]
+        public void GenerateTiles_InteriorWithoutObstacle_IsFloor()
+        {
+            var (room, template) = CreateRoomWithDoor(DoorType.Normal, isLocked: false, doorLocal: new Vector2I(15, 8));
+            var generator = new RoomTileGenerator();
+
+            var tiles = generator.GenerateTiles(room, template);
+
+            Assert.AreEqual(TileType.Floor, FindType(tiles, RoomPosition + new Vector2I(1, 1)));
+            Assert.AreEqual(TileType.Floor, FindType(tiles, RoomPosition + new Vector2I(14, 14)));
+        }
+
+        [Test]
+        public void GenerateTiles_InteriorObstaclePosition_IsObstacle()
+        {
+            var obstacle = new Vector2I(5, 5);
+            var (room, template) = CreateRoomWithDoor(
+                DoorType.Normal, isLocked: false, doorLocal: new Vector2I(15, 8), obstacles: new List<Vector2I> { obstacle });
+            var generator = new RoomTileGenerator();
+
+            var tiles = generator.GenerateTiles(room, template);
+
+            Assert.AreEqual(TileType.Obstacle, FindType(tiles, RoomPosition + obstacle));
+        }
+
+        [Test]
+        public void GenerateTiles_BoundaryWithoutDoor_IsWall()
+        {
+            var (room, template) = CreateRoomWithDoor(DoorType.Normal, isLocked: false, doorLocal: new Vector2I(15, 8));
+            var generator = new RoomTileGenerator();
+
+            var tiles = generator.GenerateTiles(room, template);
+
+            Assert.AreEqual(TileType.Wall, FindType(tiles, RoomPosition + new Vector2I(0, 0)));
+            Assert.AreEqual(TileType.Wall, FindType(tiles, RoomPosition + new Vector2I(0, 8)));
+            Assert.AreEqual(TileType.Wall, FindType(tiles, RoomPosition + new Vector2I(15, 0)));
+            Assert.AreEqual(TileType.Wall, FindType(tiles, RoomPosition + new Vector2I(15, 15)));
+        }
+
+        [Test]
+        public void GenerateTiles_NormalDoor_IsDoor()
+        {
+            var doorLocal = new Vector2I(15, 8);
+            var (room, template) = CreateRoomWithDoor(DoorType.Normal, isLocked: false, doorLocal: doorLocal);
+            var generator = new RoomTileGenerator();
+
+            var tiles = generator.GenerateTiles(room, template);
+
+            Assert.AreEqual(TileType.Door, FindType(tiles, RoomPosition + doorLocal));
+        }
+
+        [Test]
+        public void GenerateTiles_LockedDoor_IsLockedDoor()
+        {
+            var doorLocal = new Vector2I(15, 8);
+            var (room, template) = CreateRoomWithDoor(DoorType.Locked, isLocked: true, doorLocal: doorLocal);
+            var generator = new RoomTileGenerator();
+
+            var tiles = generator.GenerateTiles(room, template);
+
+            Assert.AreEqual(TileType.LockedDoor, FindType(tiles, RoomPosition + doorLocal));
+        }
+
+        [Test]
+        public void GenerateTiles_UndiscoveredSecretDoor_IsSecretWall()
+        {
+            var doorLocal = new Vector2I(15, 8);
+            var (room, template) = CreateRoomWithDoor(DoorType.Secret, isLocked: false, doorLocal: doorLocal);
+            var generator = new RoomTileGenerator();
+
+            var tiles = generator.GenerateTiles(room, template);
+
+            Assert.AreEqual(TileType.SecretWall, FindType(tiles, RoomPosition + doorLocal));
+        }
+
+        [Test]
+        public void GenerateTiles_WorldPositionOffsetByRoomPosition()
+        {
+            var (room, template) = CreateRoomWithDoor(DoorType.Normal, isLocked: false, doorLocal: new Vector2I(15, 8));
+            var generator = new RoomTileGenerator();
+
+            var tiles = generator.GenerateTiles(room, template);
+
+            // 全セルが room.Position を基準としたワールド座標範囲に収まっていること
+            Assert.IsTrue(tiles.All(t =>
+                t.WorldPosition.X >= RoomPosition.X && t.WorldPosition.X < RoomPosition.X + DungeonConstants.ROOM_SIZE &&
+                t.WorldPosition.Y >= RoomPosition.Y && t.WorldPosition.Y < RoomPosition.Y + DungeonConstants.ROOM_SIZE));
+        }
+
+        [Test]
+        public void GenerateTiles_DoorStateChangesAfterGimmickActivation_ReflectsNewType()
+        {
+            // 鍵扉解錠後（Type は Locked のまま、IsLocked のみ変化）の再生成でも扉種別自体は Type ベースで LockedDoor のままであること
+            var doorLocal = new Vector2I(15, 8);
+            var (room, template) = CreateRoomWithDoor(DoorType.Locked, isLocked: true, doorLocal: doorLocal);
+            var generator = new RoomTileGenerator();
+
+            room.Doors[0].IsLocked = false;
+            var tiles = generator.GenerateTiles(room, template);
+
+            Assert.AreEqual(TileType.LockedDoor, FindType(tiles, RoomPosition + doorLocal));
+
+            // 隠し通路発動後（Type が Secret から Normal へ変化）は Door になること
+            var (secretRoom, secretTemplate) = CreateRoomWithDoor(DoorType.Secret, isLocked: false, doorLocal: doorLocal);
+            secretRoom.Doors[0].Type = DoorType.Normal;
+            var secretTiles = generator.GenerateTiles(secretRoom, secretTemplate);
+
+            Assert.AreEqual(TileType.Door, FindType(secretTiles, RoomPosition + doorLocal));
+        }
+    }
+}

--- a/Tests/Core/Dungeon/TileMap/RoomTileGeneratorTests.cs
+++ b/Tests/Core/Dungeon/TileMap/RoomTileGeneratorTests.cs
@@ -166,7 +166,8 @@ namespace Tests.Core.Dungeon.TileMap
         [Test]
         public void GenerateTiles_DoorStateChangesAfterGimmickActivation_ReflectsNewType()
         {
-            // 鍵扉解錠後（Type は Locked のまま、IsLocked のみ変化）の再生成でも扉種別自体は Type ベースで LockedDoor のままであること
+            // 鍵扉解錠後（Type は Locked のまま、IsLocked のみ false に変化）の再生成では
+            // IsLocked も判定に使うため Door（通行可能な扉）になること
             var doorLocal = new Vector2I(15, 8);
             var (room, template) = CreateRoomWithDoor(DoorType.Locked, isLocked: true, doorLocal: doorLocal);
             var generator = new RoomTileGenerator();
@@ -174,14 +175,52 @@ namespace Tests.Core.Dungeon.TileMap
             room.Doors[0].IsLocked = false;
             var tiles = generator.GenerateTiles(room, template);
 
-            Assert.AreEqual(TileType.LockedDoor, FindType(tiles, RoomPosition + doorLocal));
+            Assert.AreEqual(TileType.Door, FindType(tiles, RoomPosition + doorLocal));
 
-            // 隠し通路発動後（Type が Secret から Normal へ変化）は Door になること
+            // 隠し通路発動後（Type が Secret から Normal へ変化）も Door になること
             var (secretRoom, secretTemplate) = CreateRoomWithDoor(DoorType.Secret, isLocked: false, doorLocal: doorLocal);
             secretRoom.Doors[0].Type = DoorType.Normal;
             var secretTiles = generator.GenerateTiles(secretRoom, secretTemplate);
 
             Assert.AreEqual(TileType.Door, FindType(secretTiles, RoomPosition + doorLocal));
+        }
+
+        [Test]
+        public void GenerateTiles_LockedDoorStillLocked_IsLockedDoor()
+        {
+            // 施錠中（IsLocked = true）の間は LockedDoor のままであること
+            var doorLocal = new Vector2I(15, 8);
+            var (room, template) = CreateRoomWithDoor(DoorType.Locked, isLocked: true, doorLocal: doorLocal);
+            var generator = new RoomTileGenerator();
+
+            var tiles = generator.GenerateTiles(room, template);
+
+            Assert.AreEqual(TileType.LockedDoor, FindType(tiles, RoomPosition + doorLocal));
+        }
+
+        [Test]
+        public void GenerateTiles_DoorCountMismatch_Throws()
+        {
+            // RoomTemplate.DoorPositions と RoomData.Doors の件数が一致しない場合は例外を投げること
+            var room = new RoomData { Position = RoomPosition, Type = RoomType.Combat };
+            room.AddDoor(new DoorData
+            {
+                Position = RoomPosition + new Vector2I(15, 8),
+                Type = DoorType.Normal,
+                IsLocked = false,
+                ConnectedRoomPosition = RoomPosition + new Vector2I(16, 0)
+            });
+
+            var template = new RoomTemplate
+            {
+                Type = RoomType.Combat,
+                ObstaclePositions = new List<Vector2I>(),
+                DoorPositions = new List<Vector2I>()
+            };
+
+            var generator = new RoomTileGenerator();
+
+            Assert.Throws<InvalidOperationException>(() => generator.GenerateTiles(room, template));
         }
     }
 }

--- a/Tests/Core/Dungeon/TileMap/TileSetManagerTests.cs
+++ b/Tests/Core/Dungeon/TileMap/TileSetManagerTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Godot;
+using Systems.Dungeon.TileMap;
+using TileType = Systems.Dungeon.TileMap.TileType;
+
+namespace Tests.Core.Dungeon.TileMap
+{
+    public class TileSetManagerTests
+    {
+        [Test]
+        public void GetTemplate_InjectedMapping_ReturnsInjectedTemplate()
+        {
+            var injected = new Dictionary<TileType, TileTemplate>
+            {
+                [TileType.Floor] = new TileTemplate { Type = TileType.Floor, SourceId = 7, AtlasCoords = new Vector2I(3, 4) }
+            };
+            var manager = new TileSetManager(injected);
+
+            var template = manager.GetTemplate(TileType.Floor);
+
+            Assert.AreEqual(7, template.SourceId);
+            Assert.AreEqual(new Vector2I(3, 4), template.AtlasCoords);
+        }
+
+        [Test]
+        public void GetTemplate_DefaultMapping_ReturnsTemplateForEveryTileType()
+        {
+            var manager = new TileSetManager();
+
+            foreach (TileType type in System.Enum.GetValues(typeof(TileType)))
+            {
+                var template = manager.GetTemplate(type);
+                Assert.AreEqual(type, template.Type);
+            }
+        }
+
+        [Test]
+        public void GetTemplate_UnregisteredType_Throws()
+        {
+            var empty = new Dictionary<TileType, TileTemplate>();
+            var manager = new TileSetManager(empty);
+
+            Assert.Throws<KeyNotFoundException>(() => manager.GetTemplate(TileType.Floor));
+        }
+
+        [Test]
+        public void GetTemplate_DefaultMapping_SecretWallLooksLikeWall()
+        {
+            var manager = new TileSetManager();
+
+            var wall = manager.GetTemplate(TileType.Wall);
+            var secretWall = manager.GetTemplate(TileType.SecretWall);
+
+            Assert.AreEqual(wall.SourceId, secretWall.SourceId);
+            Assert.AreEqual(wall.AtlasCoords, secretWall.AtlasCoords);
+        }
+    }
+}

--- a/Tests/Core/Dungeon/ViewModels/DungeonViewModelTests.cs
+++ b/Tests/Core/Dungeon/ViewModels/DungeonViewModelTests.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Godot;
+using Core.Events;
+using Systems.Dungeon.Data;
+using Systems.Dungeon.Events;
+using Systems.Dungeon.Gimmicks;
+using Systems.Dungeon.Models;
+using Systems.Dungeon.Navigation;
+using Systems.Dungeon.ViewModels;
+
+namespace Tests.Core.Dungeon.ViewModels
+{
+    public class DungeonViewModelTests
+    {
+        private static readonly Vector2I RoomAPosition = new(0, 0);
+        private static readonly Vector2I RoomBPosition = new(16, 0);
+        private static readonly Vector2I DoorAPosition = new(15, 8);
+        private static readonly Vector2I DoorBPosition = new(16, 8);
+
+        /// <summary>
+        /// テスト対象の DungeonViewModel を、実体のモデル群を注入して生成する
+        /// </summary>
+        private static DungeonViewModel CreateViewModel(GameEventBus bus)
+        {
+            return new DungeonViewModel(
+                new LevelGenerationModel(0),
+                new GimmickPlacementModel(new Random(0)),
+                new GimmickActivator(),
+                new NavigationManager(),
+                bus);
+        }
+
+        /// <summary>
+        /// 隠し通路ギミックが両側に配置された部屋ペアを作成する
+        /// </summary>
+        private static Dictionary<Vector2I, RoomData> CreateRoomsWithHiddenPassage()
+        {
+            var roomA = new RoomData { Position = RoomAPosition, Type = RoomType.Combat };
+            var roomB = new RoomData { Position = RoomBPosition, Type = RoomType.Secret };
+
+            roomA.AddDoor(new DoorData { Position = DoorAPosition, Type = DoorType.Secret, IsLocked = false, ConnectedRoomPosition = RoomBPosition });
+            roomB.AddDoor(new DoorData { Position = DoorBPosition, Type = DoorType.Secret, IsLocked = false, ConnectedRoomPosition = RoomAPosition });
+
+            roomA.AddGimmick(new GimmickData { Position = DoorAPosition, Type = GimmickType.HiddenPassage, IsActive = false });
+            roomB.AddGimmick(new GimmickData { Position = DoorBPosition, Type = GimmickType.HiddenPassage, IsActive = false });
+
+            return new Dictionary<Vector2I, RoomData> { [RoomAPosition] = roomA, [RoomBPosition] = roomB };
+        }
+
+        /// <summary>
+        /// 鍵扉ギミックが両側に配置された部屋ペアを作成する
+        /// </summary>
+        private static Dictionary<Vector2I, RoomData> CreateRoomsWithLockedDoor()
+        {
+            var roomA = new RoomData { Position = RoomAPosition, Type = RoomType.Combat };
+            var roomB = new RoomData { Position = RoomBPosition, Type = RoomType.Treasure };
+
+            roomA.AddDoor(new DoorData { Position = DoorAPosition, Type = DoorType.Locked, IsLocked = true, ConnectedRoomPosition = RoomBPosition });
+            roomB.AddDoor(new DoorData { Position = DoorBPosition, Type = DoorType.Locked, IsLocked = true, ConnectedRoomPosition = RoomAPosition });
+
+            roomA.AddGimmick(new GimmickData { Position = DoorAPosition, Type = GimmickType.LockedDoor, IsActive = false });
+            roomB.AddGimmick(new GimmickData { Position = DoorBPosition, Type = GimmickType.LockedDoor, IsActive = false });
+
+            return new Dictionary<Vector2I, RoomData> { [RoomAPosition] = roomA, [RoomBPosition] = roomB };
+        }
+
+        [Test]
+        public void Constructor_NullLevelGenerationModel_ThrowsArgumentNullException()
+        {
+            var bus = new GameEventBus();
+            Assert.Throws<ArgumentNullException>(() => _ = new DungeonViewModel(
+                null!, new GimmickPlacementModel(new Random(0)), new GimmickActivator(), new NavigationManager(), bus));
+        }
+
+        [Test]
+        public void Constructor_NullEventBus_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _ = new DungeonViewModel(
+                new LevelGenerationModel(0), new GimmickPlacementModel(new Random(0)), new GimmickActivator(), new NavigationManager(), null!));
+        }
+
+        [Test]
+        public async Task GenerateLevelAsync_ValidSeed_UpdatesRoomsAndCurrentRoomPositionAndPublishesEvent()
+        {
+            var bus = new GameEventBus();
+            var viewModel = CreateViewModel(bus);
+            LevelGeneratedEvent? received = null;
+            bus.GetEventStream<LevelGeneratedEvent>().Subscribe(e => received = e);
+
+            await viewModel.GenerateLevelAsync(42);
+
+            Assert.That(viewModel.Rooms.Value, Is.Not.Empty);
+            Assert.That(viewModel.CurrentRoomPosition.Value, Is.EqualTo(Vector2I.Zero));
+            Assert.That(viewModel.Rooms.Value.ContainsKey(Vector2I.Zero), Is.True);
+            Assert.That(received, Is.Not.Null);
+            Assert.That(received!.RoomCount, Is.EqualTo(viewModel.Rooms.Value.Count));
+        }
+
+        [Test]
+        public void EnterRoom_ExistingRoom_ReturnsTrueUpdatesCurrentRoomAndPublishesEvent()
+        {
+            var bus = new GameEventBus();
+            var viewModel = CreateViewModel(bus);
+            viewModel.Rooms.Value = CreateRoomsWithHiddenPassage();
+            RoomEnteredEvent? received = null;
+            bus.GetEventStream<RoomEnteredEvent>().Subscribe(e => received = e);
+
+            bool result = viewModel.EnterRoom(RoomBPosition);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(RoomBPosition, viewModel.CurrentRoomPosition.Value);
+            Assert.That(received, Is.Not.Null);
+            Assert.AreEqual(RoomBPosition, received!.RoomPosition);
+            Assert.AreEqual(RoomType.Secret, received!.RoomType);
+        }
+
+        [Test]
+        public void EnterRoom_NonExistingRoom_ReturnsFalseAndDoesNotPublishEvent()
+        {
+            var bus = new GameEventBus();
+            var viewModel = CreateViewModel(bus);
+            viewModel.Rooms.Value = CreateRoomsWithHiddenPassage();
+            bool received = false;
+            bus.GetEventStream<RoomEnteredEvent>().Subscribe(_ => received = true);
+
+            bool result = viewModel.EnterRoom(new Vector2I(999, 999));
+
+            Assert.IsFalse(result);
+            Assert.IsFalse(received);
+        }
+
+        [Test]
+        public void TryActivateHiddenPassage_ValidGimmick_ReturnsTrueAndPublishesRevealedEvent()
+        {
+            var bus = new GameEventBus();
+            var viewModel = CreateViewModel(bus);
+            viewModel.Rooms.Value = CreateRoomsWithHiddenPassage();
+            HiddenPassageRevealedEvent? received = null;
+            bus.GetEventStream<HiddenPassageRevealedEvent>().Subscribe(e => received = e);
+
+            bool result = viewModel.TryActivateHiddenPassage(RoomAPosition, DoorAPosition);
+
+            Assert.IsTrue(result);
+            Assert.That(received, Is.Not.Null);
+            Assert.AreEqual(RoomAPosition, received!.RoomPosition);
+            Assert.AreEqual(DoorAPosition, received!.GimmickPosition);
+            Assert.IsTrue(viewModel.Rooms.Value[RoomAPosition].Gimmicks[0].IsActive);
+        }
+
+        [Test]
+        public void TryActivateHiddenPassage_AlreadyActive_ReturnsFalseAndPublishesFailedEvent()
+        {
+            var bus = new GameEventBus();
+            var viewModel = CreateViewModel(bus);
+            viewModel.Rooms.Value = CreateRoomsWithHiddenPassage();
+            Assert.IsTrue(viewModel.TryActivateHiddenPassage(RoomAPosition, DoorAPosition));
+
+            GimmickActivationFailedEvent? received = null;
+            bus.GetEventStream<GimmickActivationFailedEvent>().Subscribe(e => received = e);
+
+            bool result = viewModel.TryActivateHiddenPassage(RoomAPosition, DoorAPosition);
+
+            Assert.IsFalse(result);
+            Assert.That(received, Is.Not.Null);
+            Assert.AreEqual(GimmickType.HiddenPassage, received!.GimmickType);
+            Assert.AreEqual(RoomAPosition, received!.RoomPosition);
+            Assert.AreEqual(DoorAPosition, received!.GimmickPosition);
+        }
+
+        [Test]
+        public void TryActivateLockedDoor_HasKey_ReturnsTrueAndPublishesUnlockedEvent()
+        {
+            var bus = new GameEventBus();
+            var viewModel = CreateViewModel(bus);
+            viewModel.Rooms.Value = CreateRoomsWithLockedDoor();
+            LockedDoorUnlockedEvent? received = null;
+            bus.GetEventStream<LockedDoorUnlockedEvent>().Subscribe(e => received = e);
+
+            bool result = viewModel.TryActivateLockedDoor(RoomAPosition, DoorAPosition, hasKey: true);
+
+            Assert.IsTrue(result);
+            Assert.That(received, Is.Not.Null);
+            Assert.AreEqual(RoomAPosition, received!.RoomPosition);
+            Assert.AreEqual(DoorAPosition, received!.GimmickPosition);
+            Assert.IsFalse(viewModel.Rooms.Value[RoomAPosition].Doors[0].IsLocked);
+        }
+
+        [Test]
+        public void TryActivateLockedDoor_NoKey_ReturnsFalseAndPublishesFailedEvent()
+        {
+            var bus = new GameEventBus();
+            var viewModel = CreateViewModel(bus);
+            viewModel.Rooms.Value = CreateRoomsWithLockedDoor();
+            GimmickActivationFailedEvent? received = null;
+            bus.GetEventStream<GimmickActivationFailedEvent>().Subscribe(e => received = e);
+
+            bool result = viewModel.TryActivateLockedDoor(RoomAPosition, DoorAPosition, hasKey: false);
+
+            Assert.IsFalse(result);
+            Assert.That(received, Is.Not.Null);
+            Assert.AreEqual(GimmickType.LockedDoor, received!.GimmickType);
+            Assert.AreEqual(RoomAPosition, received!.RoomPosition);
+            Assert.AreEqual(DoorAPosition, received!.GimmickPosition);
+            Assert.IsTrue(viewModel.Rooms.Value[RoomAPosition].Doors[0].IsLocked);
+        }
+    }
+}

--- a/Tests/Core/Dungeon/ViewModels/DungeonViewModelTests.cs
+++ b/Tests/Core/Dungeon/ViewModels/DungeonViewModelTests.cs
@@ -151,6 +151,22 @@ namespace Tests.Core.Dungeon.ViewModels
         }
 
         [Test]
+        public void TryActivateHiddenPassage_ValidGimmick_NotifiesRoomsSubscribers()
+        {
+            var bus = new GameEventBus();
+            var viewModel = CreateViewModel(bus);
+            viewModel.Rooms.Value = CreateRoomsWithHiddenPassage();
+            bool notified = false;
+            viewModel.Rooms.Subscribe(_ => notified = true);
+
+            // ギミック発動は RoomData を in-place で書き換えるため、Rooms の変更通知が確実に発火することを確認する
+            bool result = viewModel.TryActivateHiddenPassage(RoomAPosition, DoorAPosition);
+
+            Assert.IsTrue(result);
+            Assert.IsTrue(notified);
+        }
+
+        [Test]
         public void TryActivateHiddenPassage_AlreadyActive_ReturnsFalseAndPublishesFailedEvent()
         {
             var bus = new GameEventBus();

--- a/Tests/Core/Dungeon/ViewModels/RoomViewModelTests.cs
+++ b/Tests/Core/Dungeon/ViewModels/RoomViewModelTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using Godot;
 using Core.Events;
@@ -32,10 +33,10 @@ namespace Tests.Core.Dungeon.ViewModels
 
             var viewModel = new RoomViewModel(room, bus);
 
-            Assert.AreEqual(RoomType.Treasure, viewModel.Type.Value);
+            Assert.AreEqual(RoomType.Treasure, viewModel.Type);
             Assert.IsFalse(viewModel.IsVisited.Value);
-            Assert.AreEqual(1, viewModel.Doors.Count);
-            Assert.AreEqual(1, viewModel.Gimmicks.Count);
+            Assert.AreEqual(1, viewModel.Doors.Value.Count);
+            Assert.AreEqual(1, viewModel.Gimmicks.Value.Count);
         }
 
         [Test]
@@ -50,16 +51,25 @@ namespace Tests.Core.Dungeon.ViewModels
         }
 
         [Test]
-        public void Doors_ReflectsLatestRoomDataState()
+        public void Refresh_AfterRoomDataChanges_NotifiesSubscribersWithUpdatedSnapshot()
         {
             var bus = new GameEventBus();
             var room = CreateRoom();
             var viewModel = new RoomViewModel(room, bus);
+            IReadOnlyList<DoorData>? notifiedDoors = null;
+            viewModel.Doors.Subscribe(doors => notifiedDoors = doors);
 
-            // RoomData 側の扉状態が書き換わった場合、ViewModel 経由でも最新状態が見えること
+            // RoomData.Doors の要素は同一インスタンス参照のため、Refresh を呼ぶ前でも
+            // ReactiveProperty のスナップショット経由で最新のフィールド値自体は見える
             room.Doors[0].IsLocked = false;
+            Assert.IsFalse(viewModel.Doors.Value[0].IsLocked);
 
-            Assert.IsFalse(viewModel.Doors[0].IsLocked);
+            // Refresh を呼び出すことで初めて、購読者への変更通知（Subscribe）が発火すること
+            Assert.IsNull(notifiedDoors);
+            viewModel.Refresh();
+
+            Assert.IsNotNull(notifiedDoors);
+            Assert.IsFalse(notifiedDoors![0].IsLocked);
         }
     }
 }

--- a/Tests/Core/Dungeon/ViewModels/RoomViewModelTests.cs
+++ b/Tests/Core/Dungeon/ViewModels/RoomViewModelTests.cs
@@ -1,0 +1,65 @@
+using System;
+using NUnit.Framework;
+using Godot;
+using Core.Events;
+using Systems.Dungeon.Data;
+using Systems.Dungeon.ViewModels;
+
+namespace Tests.Core.Dungeon.ViewModels
+{
+    public class RoomViewModelTests
+    {
+        private static RoomData CreateRoom()
+        {
+            var room = new RoomData { Position = Vector2I.Zero, Type = RoomType.Treasure };
+            room.AddDoor(new DoorData { Position = new Vector2I(1, 1), Type = DoorType.Locked, IsLocked = true, ConnectedRoomPosition = new Vector2I(16, 0) });
+            room.AddGimmick(new GimmickData { Position = new Vector2I(1, 1), Type = GimmickType.LockedDoor, IsActive = false });
+            return room;
+        }
+
+        [Test]
+        public void Constructor_NullRoom_ThrowsArgumentNullException()
+        {
+            var bus = new GameEventBus();
+            Assert.Throws<ArgumentNullException>(() => _ = new RoomViewModel(null!, bus));
+        }
+
+        [Test]
+        public void Constructor_InitialState_ReflectsRoomData()
+        {
+            var bus = new GameEventBus();
+            var room = CreateRoom();
+
+            var viewModel = new RoomViewModel(room, bus);
+
+            Assert.AreEqual(RoomType.Treasure, viewModel.Type.Value);
+            Assert.IsFalse(viewModel.IsVisited.Value);
+            Assert.AreEqual(1, viewModel.Doors.Count);
+            Assert.AreEqual(1, viewModel.Gimmicks.Count);
+        }
+
+        [Test]
+        public void MarkVisited_SetsIsVisitedTrue()
+        {
+            var bus = new GameEventBus();
+            var viewModel = new RoomViewModel(CreateRoom(), bus);
+
+            viewModel.MarkVisited();
+
+            Assert.IsTrue(viewModel.IsVisited.Value);
+        }
+
+        [Test]
+        public void Doors_ReflectsLatestRoomDataState()
+        {
+            var bus = new GameEventBus();
+            var room = CreateRoom();
+            var viewModel = new RoomViewModel(room, bus);
+
+            // RoomData 側の扉状態が書き換わった場合、ViewModel 経由でも最新状態が見えること
+            room.Doors[0].IsLocked = false;
+
+            Assert.IsFalse(viewModel.Doors[0].IsLocked);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Week 1の基盤（RoomData/DoorData/LevelGenerationModel等）を拡張し、Week 2計画書（`Docs/06_DevelopmentPlan/11_18_week2_dungeon_extension_plan.md`）のPhase 1〜4を実装
- Gimmicks: 隠し通路・鍵扉の配置（`GimmickPlacementModel`）と発動管理（`GimmickActivator`）
- Navigation: A*経路探索（`PathFinder`）、ギミック状態（施錠/隠蔽）に連動した通行判定を持つ`NavigationMesh`/`NavigationManager`
- TileMap: 部屋データからタイル配置を生成する純粋ロジック（`RoomTileGenerator`等）と、Godotノード依存部分を薄く保った`TileMapManager`/`TileRenderer`
- ViewModels/Events: `Core.ViewModels`/`Core.Events`基盤に準拠した`DungeonViewModel`/`RoomViewModel`/`DungeonEvents`で全システムを統合

## Test plan
- [x] `dotnet build` — 0 Warning(s), 0 Error(s)
- [x] `dotnet test Tests/Core/CoreTests.csproj` — 196件全pass（Week1分含む）
- [ ] GUT (GDScript) テストは未実施 — TileMapManager/TileRendererはGodotノード依存のロジックを持たない薄いラッパーとして設計し、ロジック本体はNUnitでカバー
- [ ] 実際の`.tres`タイルセット資産は未作成（プレースホルダーのアトラス座標マッピングのみ）

AX-Tag: ai-work

🤖 Generated with [Claude Code](https://claude.com/claude-code)