### PR TITLE
feat: ダンジョン統合Phase A/B実装 (Week3 Day1-3)

### DIFF
--- a/Docs/06_DevelopmentPlan/11_19_week3_dungeon_integration_test_plan.md
+++ b/Docs/06_DevelopmentPlan/11_19_week3_dungeon_integration_test_plan.md
@@ -1,8 +1,8 @@
 ---
 title: Week 3: ダンジョン生成システム統合・テスト実装計画
-version: 0.1.0
-status: draft
-updated: 2025-06-20
+version: 0.2.0
+status: in-progress
+updated: 2026-07-17
 tags:
     - Implementation
     - Plan
@@ -61,19 +61,19 @@ Week 1・2で実装した各コンポーネントを統合し、UI/UX・自動�
 ## 3. 日別実装計画
 
 ### Day 1: システム統合準備
-- 各システムのAPI・インターフェース確認
-- 統合用ブランチ作成・マージ戦略決定
-- 統合テスト用シーン/エントリーポイント作成
+- [x] 各システムのAPI・インターフェース確認
+- [x] 統合用ブランチ作成・マージ戦略決定（`feat/week3-dungeon-integration`ブランチ、専用worktreeで作業）
+- [x] 統合テスト用シーン/エントリーポイント作成（`Scenes/Dungeon/DungeonDebug.tscn`）
 
 ### Day 2: コア統合実装
-- DungeonViewModelを中心としたシステム連携
-- イベント伝播の動作確認
-- デバッグUI（部屋情報・ギミック状態・経路表示等）の仮実装
+- [x] DungeonViewModelを中心としたシステム連携（`Scripts/Systems/Dungeon/Views/DungeonView.cs`で構築・初期化）
+- [x] イベント伝播の動作確認（`LevelGeneratedEvent`等のデバッグログ出力で確認）
+- [x] デバッグUI（部屋情報・ギミック状態・経路表示等）の仮実装（Day 3で本実装へ発展）
 
 ### Day 3: UI/UX統合
-- 最低限のUI（部屋遷移、ギミック発動、経路表示など）の実装
-- プレイヤー操作とダンジョン状態の連動
-- UIイベントとViewModelのバインディング
+- [x] 最低限のUI（部屋遷移、ギミック発動、経路表示など）の実装
+- [x] プレイヤー操作とダンジョン状態の連動（ボタン押下 → ViewModel呼び出し → イベント発行 → UI更新）
+- [x] UIイベントとViewModelのバインディング（`RoomEnteredEvent`/`HiddenPassageRevealedEvent`/`LockedDoorUnlockedEvent`/`GimmickActivationFailedEvent`の購読でラベル・ボタン・タイル表示を更新）
 
 ### Day 4: 単体テスト拡充
 - 各システムのテストケース追加・修正
@@ -160,5 +160,6 @@ Week 1・2で実装した各コンポーネントを統合し、UI/UX・自動�
 
 | バージョン | 更新日     | 変更内容 |
 | ---------- | ---------- | -------- |
+| 0.2.0      | 2026-07-17 | Day 1-3 実装完了を反映<br>- Day 1-2（Phase A）: `Scenes/Dungeon/DungeonDebug.tscn`・`Scripts/Systems/Dungeon/Views/DungeonView.cs`を追加し、`DungeonViewModel`によるレベル生成・タイルマップ反映・イベントログ出力までを統合<br>- Day 3（Phase B）: 部屋遷移（隣接部屋への遷移ボタン）・ギミック発動（隠し通路/鍵扉、鍵所持は簡易的に常にtrue扱い）・経路表示（`FindPath`結果を`Line2D`で描画）の最低限のデバッグUIを`DungeonView`に追加。`RoomEnteredEvent`/`HiddenPassageRevealedEvent`/`LockedDoorUnlockedEvent`/`GimmickActivationFailedEvent`購読によるUI更新も実装<br>- `RoomTileGenerator.GetDoorTileType`を公開化し、ギミック発動後の扉タイル再描画に対応<br>- `dotnet test Tests/Core/CoreTests.csproj` 201件全pass（うちダンジョン関連113件）、`dotnet build` 0警告0エラー<br>- 未実施: Day 4-7（単体テスト拡充・統合テスト自動化・CI/CD・パフォーマンス最適化・ドキュメント整備）、テストカバレッジ計測、実際の`.tres`タイルセット資産の作成 |
 | 0.1.0      | 2025-06-20 | 初版作成<br>- Week 3統合・テスト実装計画<br>- 7日間の日別実装スケジュール<br>- システム統合とUI/UX統合の詳細<br>- テスト戦略とリスク管理 |
 

--- a/Scenes/Dungeon/DungeonDebug.tscn
+++ b/Scenes/Dungeon/DungeonDebug.tscn
@@ -7,8 +7,28 @@ script = ExtResource("1")
 
 [node name="TileMapLayer" type="TileMapLayer" parent="."]
 
+[node name="PathLine" type="Line2D" parent="."]
+width = 2.0
+default_color = Color(1, 1, 0, 1)
+
 [node name="DebugUI" type="CanvasLayer" parent="."]
 
-[node name="DebugLabel" type="Control" parent="DebugUI"]
+[node name="RootPanel" type="VBoxContainer" parent="DebugUI"]
 layout_mode = 3
 anchors_preset = 0
+offset_left = 16.0
+offset_top = 16.0
+
+[node name="RoomInfoLabel" type="Label" parent="DebugUI/RootPanel"]
+layout_mode = 2
+text = "現在の部屋: -"
+
+[node name="ResultLabel" type="Label" parent="DebugUI/RootPanel"]
+layout_mode = 2
+text = "-"
+
+[node name="RoomButtonsContainer" type="HBoxContainer" parent="DebugUI/RootPanel"]
+layout_mode = 2
+
+[node name="GimmickButtonsContainer" type="VBoxContainer" parent="DebugUI/RootPanel"]
+layout_mode = 2

--- a/Scenes/Dungeon/DungeonDebug.tscn
+++ b/Scenes/Dungeon/DungeonDebug.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://Scripts/Systems/Dungeon/Views/DungeonView.cs" id="1"]
+
+[node name="DungeonDebug" type="Node2D"]
+script = ExtResource("1")
+
+[node name="TileMapLayer" type="TileMapLayer" parent="."]
+
+[node name="DebugUI" type="CanvasLayer" parent="."]
+
+[node name="DebugLabel" type="Control" parent="DebugUI"]
+layout_mode = 3
+anchors_preset = 0

--- a/Scripts/Systems/Dungeon/TileMap/RoomTileGenerator.cs
+++ b/Scripts/Systems/Dungeon/TileMap/RoomTileGenerator.cs
@@ -104,6 +104,18 @@ namespace Systems.Dungeon.TileMap
                 return TileType.Wall;
             }
 
+            return GetDoorTileType(door);
+        }
+
+        /// <summary>
+        /// 扉データの種類・施錠状態からタイル種別を判定する
+        /// 隠し通路発動・鍵扉解錠等で <see cref="RoomData"/> 側の状態のみが変化した際に、
+        /// 部屋全体を再生成せずタイルマップ上の該当セルのみを個別更新する用途にも使用する
+        /// </summary>
+        /// <param name="door">判定対象の扉データ</param>
+        /// <returns>扉の種類・施錠状態に応じたタイル種別</returns>
+        public static TileType GetDoorTileType(DoorData door)
+        {
             if (door.Type == DoorType.Secret)
             {
                 return TileType.SecretWall;

--- a/Scripts/Systems/Dungeon/Views/DungeonView.cs
+++ b/Scripts/Systems/Dungeon/Views/DungeonView.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Core.Events;
+using Core.Reactive;
 using Godot;
 using Systems.Dungeon.Data;
 using Systems.Dungeon.Events;
@@ -62,7 +63,7 @@ namespace Systems.Dungeon.Views
         private readonly RoomTileGenerator _roomTileGenerator = new();
         private readonly TileSetManager _tileSetManager = new();
         private readonly TileMapManager _tileMapManager = new();
-        private readonly List<IDisposable> _eventSubscriptions = new();
+        private readonly CompositeDisposable _eventSubscriptions = new();
 
         /// <summary>
         /// ノード初期化
@@ -100,13 +101,20 @@ namespace Systems.Dungeon.Views
         /// <summary>
         /// レベル生成を行い、完了後に全部屋をタイルマップへ反映する
         /// Godotの<see cref="_Ready"/>は同期メソッドのため、非同期処理はfire-and-forgetの
-        /// async voidヘルパーとして切り出す
+        /// async voidヘルパーとして切り出す。失敗時は GD.PrintErr でログ出力する
         /// </summary>
         private async void InitializeLevelAsync()
         {
-            await _viewModel.GenerateLevelAsync(DebugSeed);
-            RenderRooms();
-            RefreshRoomUi();
+            try
+            {
+                await _viewModel.GenerateLevelAsync(DebugSeed);
+                RenderRooms();
+                RefreshRoomUi();
+            }
+            catch (Exception e)
+            {
+                GD.PrintErr($"[DungeonView] レベル初期化に失敗しました: {e}");
+            }
         }
 
         /// <summary>
@@ -330,12 +338,7 @@ namespace Systems.Dungeon.Views
         /// </summary>
         public override void _ExitTree()
         {
-            foreach (var subscription in _eventSubscriptions)
-            {
-                subscription.Dispose();
-            }
-            _eventSubscriptions.Clear();
-
+            _eventSubscriptions.Dispose();
             _tileMapManager.Free();
             _viewModel.Dispose();
         }

--- a/Scripts/Systems/Dungeon/Views/DungeonView.cs
+++ b/Scripts/Systems/Dungeon/Views/DungeonView.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Core.Events;
 using Godot;
+using Systems.Dungeon.Data;
 using Systems.Dungeon.Events;
 using Systems.Dungeon.Gimmicks;
 using Systems.Dungeon.Models;
 using Systems.Dungeon.Navigation;
 using Systems.Dungeon.TileMap;
+using Systems.Dungeon.Utilities;
 using Systems.Dungeon.ViewModels;
 
 namespace Systems.Dungeon.Views
@@ -29,12 +32,37 @@ namespace Systems.Dungeon.Views
         /// </summary>
         private TileMapLayer _tileMapLayer = default!;
 
+        /// <summary>
+        /// 経路表示用の線（シーン上の子ノード "PathLine" を使用）
+        /// </summary>
+        private Line2D _pathLine = default!;
+
+        /// <summary>
+        /// 現在の部屋情報を表示するラベル
+        /// </summary>
+        private Label _roomInfoLabel = default!;
+
+        /// <summary>
+        /// 直近の操作結果（入室・ギミック発動成否）を表示するラベル
+        /// </summary>
+        private Label _resultLabel = default!;
+
+        /// <summary>
+        /// 隣接部屋への遷移ボタンを並べるコンテナ
+        /// </summary>
+        private HBoxContainer _roomButtonsContainer = default!;
+
+        /// <summary>
+        /// 未発動ギミックの発動ボタンを並べるコンテナ
+        /// </summary>
+        private VBoxContainer _gimmickButtonsContainer = default!;
+
         private DungeonViewModel _viewModel = default!;
         private LevelGenerationModel _levelGenerationModel = default!;
         private readonly RoomTileGenerator _roomTileGenerator = new();
         private readonly TileSetManager _tileSetManager = new();
         private readonly TileMapManager _tileMapManager = new();
-        private readonly List<IDisposable> _debugLogSubscriptions = new();
+        private readonly List<IDisposable> _eventSubscriptions = new();
 
         /// <summary>
         /// ノード初期化
@@ -44,6 +72,11 @@ namespace Systems.Dungeon.Views
         public override void _Ready()
         {
             _tileMapLayer = GetNode<TileMapLayer>("TileMapLayer");
+            _pathLine = GetNode<Line2D>("PathLine");
+            _roomInfoLabel = GetNode<Label>("DebugUI/RootPanel/RoomInfoLabel");
+            _resultLabel = GetNode<Label>("DebugUI/RootPanel/ResultLabel");
+            _roomButtonsContainer = GetNode<HBoxContainer>("DebugUI/RootPanel/RoomButtonsContainer");
+            _gimmickButtonsContainer = GetNode<VBoxContainer>("DebugUI/RootPanel/GimmickButtonsContainer");
 
             var eventBus = GameEventBus.Instance;
             _levelGenerationModel = new LevelGenerationModel(DebugSeed);
@@ -59,6 +92,7 @@ namespace Systems.Dungeon.Views
                 eventBus);
 
             SubscribeDebugLogs(eventBus);
+            SubscribeUiUpdates(eventBus);
 
             InitializeLevelAsync();
         }
@@ -72,6 +106,7 @@ namespace Systems.Dungeon.Views
         {
             await _viewModel.GenerateLevelAsync(DebugSeed);
             RenderRooms();
+            RefreshRoomUi();
         }
 
         /// <summary>
@@ -97,16 +132,197 @@ namespace Systems.Dungeon.Views
         /// <param name="eventBus">購読対象のイベントバス</param>
         private void SubscribeDebugLogs(IGameEventBus eventBus)
         {
-            _debugLogSubscriptions.Add(eventBus.GetEventStream<LevelGeneratedEvent>()
+            _eventSubscriptions.Add(eventBus.GetEventStream<LevelGeneratedEvent>()
                 .Subscribe(e => GD.Print($"[Dungeon] LevelGenerated: RoomCount={e.RoomCount}")));
-            _debugLogSubscriptions.Add(eventBus.GetEventStream<RoomEnteredEvent>()
+            _eventSubscriptions.Add(eventBus.GetEventStream<RoomEnteredEvent>()
                 .Subscribe(e => GD.Print($"[Dungeon] RoomEntered: Position={e.RoomPosition} Type={e.RoomType}")));
-            _debugLogSubscriptions.Add(eventBus.GetEventStream<HiddenPassageRevealedEvent>()
+            _eventSubscriptions.Add(eventBus.GetEventStream<HiddenPassageRevealedEvent>()
                 .Subscribe(e => GD.Print($"[Dungeon] HiddenPassageRevealed: Room={e.RoomPosition} Gimmick={e.GimmickPosition}")));
-            _debugLogSubscriptions.Add(eventBus.GetEventStream<LockedDoorUnlockedEvent>()
+            _eventSubscriptions.Add(eventBus.GetEventStream<LockedDoorUnlockedEvent>()
                 .Subscribe(e => GD.Print($"[Dungeon] LockedDoorUnlocked: Room={e.RoomPosition} Gimmick={e.GimmickPosition}")));
-            _debugLogSubscriptions.Add(eventBus.GetEventStream<GimmickActivationFailedEvent>()
+            _eventSubscriptions.Add(eventBus.GetEventStream<GimmickActivationFailedEvent>()
                 .Subscribe(e => GD.Print($"[Dungeon] GimmickActivationFailed: Room={e.RoomPosition} Gimmick={e.GimmickPosition} Type={e.GimmickType}")));
+        }
+
+        /// <summary>
+        /// UI表示更新用のイベント購読を登録する
+        /// 部屋入室・ギミック発動結果に応じて、現在部屋情報ラベル・結果ラベル・遷移/発動ボタン・タイル表示を更新する
+        /// </summary>
+        /// <param name="eventBus">購読対象のイベントバス</param>
+        private void SubscribeUiUpdates(IGameEventBus eventBus)
+        {
+            _eventSubscriptions.Add(eventBus.GetEventStream<RoomEnteredEvent>()
+                .Subscribe(e =>
+                {
+                    _resultLabel.Text = $"入室: {e.RoomPosition} ({e.RoomType})";
+                    RefreshRoomUi();
+                }));
+            _eventSubscriptions.Add(eventBus.GetEventStream<HiddenPassageRevealedEvent>()
+                .Subscribe(e =>
+                {
+                    _resultLabel.Text = $"隠し通路を発見しました: {e.GimmickPosition}";
+                    RefreshDoorTiles(e.RoomPosition, e.GimmickPosition);
+                    RefreshRoomUi();
+                }));
+            _eventSubscriptions.Add(eventBus.GetEventStream<LockedDoorUnlockedEvent>()
+                .Subscribe(e =>
+                {
+                    _resultLabel.Text = $"鍵扉を解錠しました: {e.GimmickPosition}";
+                    RefreshDoorTiles(e.RoomPosition, e.GimmickPosition);
+                    RefreshRoomUi();
+                }));
+            _eventSubscriptions.Add(eventBus.GetEventStream<GimmickActivationFailedEvent>()
+                .Subscribe(e =>
+                {
+                    _resultLabel.Text = $"ギミック発動に失敗しました: {e.GimmickType} @ {e.GimmickPosition}";
+                }));
+        }
+
+        /// <summary>
+        /// 現在の部屋情報表示・遷移ボタン・ギミック発動ボタンを最新状態へ再構築する
+        /// </summary>
+        private void RefreshRoomUi()
+        {
+            var currentPosition = _viewModel.CurrentRoomPosition.Value;
+            if (!_viewModel.Rooms.Value.TryGetValue(currentPosition, out var room))
+            {
+                return;
+            }
+
+            _roomInfoLabel.Text = $"現在の部屋: {currentPosition} ({room.Type})";
+
+            RebuildRoomButtons(currentPosition, room);
+            RebuildGimmickButtons(currentPosition, room);
+        }
+
+        /// <summary>
+        /// 現在の部屋が持つ扉ごとに、接続先の部屋へ遷移するボタンを再構築する
+        /// 鍵扉・隠し扉の未開通状態にかかわらず、デバッグ用途として全ての扉を遷移対象として表示する
+        /// </summary>
+        /// <param name="currentPosition">現在の部屋の位置</param>
+        /// <param name="room">現在の部屋データ</param>
+        private void RebuildRoomButtons(Vector2I currentPosition, RoomData room)
+        {
+            foreach (var child in _roomButtonsContainer.GetChildren())
+            {
+                child.QueueFree();
+            }
+
+            foreach (var door in room.Doors)
+            {
+                var targetPosition = door.ConnectedRoomPosition;
+                var button = new Button { Text = $"→ {targetPosition} [{door.Type}]" };
+                button.Pressed += () => OnRoomTransitionPressed(currentPosition, targetPosition);
+                _roomButtonsContainer.AddChild(button);
+            }
+        }
+
+        /// <summary>
+        /// 現在の部屋が持つ未発動ギミック（隠し通路・鍵扉）ごとに、発動を試みるボタンを再構築する
+        /// </summary>
+        /// <param name="currentPosition">現在の部屋の位置</param>
+        /// <param name="room">現在の部屋データ</param>
+        private void RebuildGimmickButtons(Vector2I currentPosition, RoomData room)
+        {
+            foreach (var child in _gimmickButtonsContainer.GetChildren())
+            {
+                child.QueueFree();
+            }
+
+            foreach (var gimmick in room.Gimmicks)
+            {
+                if (gimmick.IsActive) continue;
+                if (gimmick.Type != GimmickType.HiddenPassage && gimmick.Type != GimmickType.LockedDoor) continue;
+
+                var button = new Button { Text = $"発動: {gimmick.Type} @ {gimmick.Position}" };
+                button.Pressed += () => OnGimmickActivatePressed(currentPosition, gimmick);
+                _gimmickButtonsContainer.AddChild(button);
+            }
+        }
+
+        /// <summary>
+        /// 部屋遷移ボタン押下時の処理
+        /// 現在部屋の中心から遷移先部屋の中心までの経路を表示したうえで、遷移先の部屋へ入室する
+        /// </summary>
+        /// <param name="fromPosition">現在の部屋の位置</param>
+        /// <param name="targetPosition">遷移先の部屋の位置</param>
+        private void OnRoomTransitionPressed(Vector2I fromPosition, Vector2I targetPosition)
+        {
+            DrawPathPreview(fromPosition, targetPosition);
+            _viewModel.EnterRoom(targetPosition);
+        }
+
+        /// <summary>
+        /// ギミック発動ボタン押下時の処理
+        /// 鍵の所持は簡易的に常に true として扱う（本格的なアイテムシステムは対象外）
+        /// </summary>
+        /// <param name="roomPosition">ギミックが属する部屋の位置</param>
+        /// <param name="gimmick">発動対象のギミックデータ</param>
+        private void OnGimmickActivatePressed(Vector2I roomPosition, GimmickData gimmick)
+        {
+            if (gimmick.Type == GimmickType.HiddenPassage)
+            {
+                _viewModel.TryActivateHiddenPassage(roomPosition, gimmick.Position);
+            }
+            else if (gimmick.Type == GimmickType.LockedDoor)
+            {
+                _viewModel.TryActivateLockedDoor(roomPosition, gimmick.Position, hasKey: true);
+            }
+        }
+
+        /// <summary>
+        /// 部屋の中心タイル同士の経路を探索し、<see cref="_pathLine"/> へ反映する
+        /// </summary>
+        /// <param name="fromRoomPosition">開始部屋の位置</param>
+        /// <param name="toRoomPosition">目標部屋の位置</param>
+        private void DrawPathPreview(Vector2I fromRoomPosition, Vector2I toRoomPosition)
+        {
+            var roomCenterOffset = new Vector2I(DungeonConstants.ROOM_SIZE / 2, DungeonConstants.ROOM_SIZE / 2);
+            var startTile = fromRoomPosition + roomCenterOffset;
+            var goalTile = toRoomPosition + roomCenterOffset;
+
+            var path = _viewModel.FindPath(startTile, goalTile);
+            _pathLine.Points = path.Select(tile => _tileMapLayer.MapToLocal(tile)).ToArray();
+        }
+
+        /// <summary>
+        /// ギミック発動により状態が変化した扉のタイルを、自室・接続先の部屋の両方について再描画する
+        /// </summary>
+        /// <param name="roomPosition">ギミックが属していた部屋の位置</param>
+        /// <param name="doorPosition">状態が変化した扉の位置（ギミック位置と同一）</param>
+        private void RefreshDoorTiles(Vector2I roomPosition, Vector2I doorPosition)
+        {
+            if (!_viewModel.Rooms.Value.TryGetValue(roomPosition, out var room))
+            {
+                return;
+            }
+
+            var door = room.Doors.FirstOrDefault(d => d.Position == doorPosition);
+            if (door == null)
+            {
+                return;
+            }
+
+            UpdateDoorTile(door);
+
+            if (_viewModel.Rooms.Value.TryGetValue(door.ConnectedRoomPosition, out var connectedRoom))
+            {
+                var connectedDoor = connectedRoom.GetDoorTo(roomPosition);
+                if (connectedDoor != null)
+                {
+                    UpdateDoorTile(connectedDoor);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 単一の扉タイルを現在の扉データの状態に合わせて更新する
+        /// </summary>
+        /// <param name="door">更新対象の扉データ</param>
+        private void UpdateDoorTile(DoorData door)
+        {
+            var type = RoomTileGenerator.GetDoorTileType(door);
+            _tileMapManager.UpdateTile(_tileMapLayer, door.Position, type, _tileSetManager);
         }
 
         /// <summary>
@@ -114,11 +330,11 @@ namespace Systems.Dungeon.Views
         /// </summary>
         public override void _ExitTree()
         {
-            foreach (var subscription in _debugLogSubscriptions)
+            foreach (var subscription in _eventSubscriptions)
             {
                 subscription.Dispose();
             }
-            _debugLogSubscriptions.Clear();
+            _eventSubscriptions.Clear();
 
             _tileMapManager.Free();
             _viewModel.Dispose();

--- a/Scripts/Systems/Dungeon/Views/DungeonView.cs
+++ b/Scripts/Systems/Dungeon/Views/DungeonView.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using Core.Events;
+using Godot;
+using Systems.Dungeon.Events;
+using Systems.Dungeon.Gimmicks;
+using Systems.Dungeon.Models;
+using Systems.Dungeon.Navigation;
+using Systems.Dungeon.TileMap;
+using Systems.Dungeon.ViewModels;
+
+namespace Systems.Dungeon.Views
+{
+    /// <summary>
+    /// ダンジョンビュー
+    /// <see cref="DungeonViewModel"/>（レベル生成・ギミック配置・ナビゲーション統合）を初期化し、
+    /// 生成結果をタイルマップへ反映する。ロジックはModel/ViewModel層に委ね、
+    /// 本クラスはGodotノードとの薄い橋渡しに徹する
+    /// </summary>
+    public partial class DungeonView : Node2D
+    {
+        /// <summary>
+        /// デバッグ用の固定レベル生成シード値
+        /// </summary>
+        private const int DebugSeed = 12345;
+
+        /// <summary>
+        /// タイルマップの反映先レイヤー（シーン上の子ノード "TileMapLayer" を使用）
+        /// </summary>
+        private TileMapLayer _tileMapLayer = default!;
+
+        private DungeonViewModel _viewModel = default!;
+        private LevelGenerationModel _levelGenerationModel = default!;
+        private readonly RoomTileGenerator _roomTileGenerator = new();
+        private readonly TileSetManager _tileSetManager = new();
+        private readonly TileMapManager _tileMapManager = new();
+        private readonly List<IDisposable> _debugLogSubscriptions = new();
+
+        /// <summary>
+        /// ノード初期化
+        /// Model/ViewModel層を構築し、デバッグ用イベントログ購読を登録したうえで
+        /// 固定シードによるレベル生成を開始する
+        /// </summary>
+        public override void _Ready()
+        {
+            _tileMapLayer = GetNode<TileMapLayer>("TileMapLayer");
+
+            var eventBus = GameEventBus.Instance;
+            _levelGenerationModel = new LevelGenerationModel(DebugSeed);
+            var gimmickPlacementModel = new GimmickPlacementModel(new Random(DebugSeed));
+            var gimmickActivator = new GimmickActivator();
+            var navigationManager = new NavigationManager();
+
+            _viewModel = new DungeonViewModel(
+                _levelGenerationModel,
+                gimmickPlacementModel,
+                gimmickActivator,
+                navigationManager,
+                eventBus);
+
+            SubscribeDebugLogs(eventBus);
+
+            InitializeLevelAsync();
+        }
+
+        /// <summary>
+        /// レベル生成を行い、完了後に全部屋をタイルマップへ反映する
+        /// Godotの<see cref="_Ready"/>は同期メソッドのため、非同期処理はfire-and-forgetの
+        /// async voidヘルパーとして切り出す
+        /// </summary>
+        private async void InitializeLevelAsync()
+        {
+            await _viewModel.GenerateLevelAsync(DebugSeed);
+            RenderRooms();
+        }
+
+        /// <summary>
+        /// 生成済みの全部屋をタイルマップへ反映する
+        /// </summary>
+        private void RenderRooms()
+        {
+            foreach (var (position, room) in _viewModel.Rooms.Value)
+            {
+                if (!_levelGenerationModel.RoomTemplates.TryGetValue(position, out var template))
+                {
+                    continue;
+                }
+
+                var tiles = _roomTileGenerator.GenerateTiles(room, template);
+                _tileMapManager.ApplyTiles(_tileMapLayer, tiles, _tileSetManager);
+            }
+        }
+
+        /// <summary>
+        /// ダンジョン関連イベントの発行状況をデバッグログ（<see cref="GD.Print(Variant[])"/>）へ出力する購読を登録する
+        /// </summary>
+        /// <param name="eventBus">購読対象のイベントバス</param>
+        private void SubscribeDebugLogs(IGameEventBus eventBus)
+        {
+            _debugLogSubscriptions.Add(eventBus.GetEventStream<LevelGeneratedEvent>()
+                .Subscribe(e => GD.Print($"[Dungeon] LevelGenerated: RoomCount={e.RoomCount}")));
+            _debugLogSubscriptions.Add(eventBus.GetEventStream<RoomEnteredEvent>()
+                .Subscribe(e => GD.Print($"[Dungeon] RoomEntered: Position={e.RoomPosition} Type={e.RoomType}")));
+            _debugLogSubscriptions.Add(eventBus.GetEventStream<HiddenPassageRevealedEvent>()
+                .Subscribe(e => GD.Print($"[Dungeon] HiddenPassageRevealed: Room={e.RoomPosition} Gimmick={e.GimmickPosition}")));
+            _debugLogSubscriptions.Add(eventBus.GetEventStream<LockedDoorUnlockedEvent>()
+                .Subscribe(e => GD.Print($"[Dungeon] LockedDoorUnlocked: Room={e.RoomPosition} Gimmick={e.GimmickPosition}")));
+            _debugLogSubscriptions.Add(eventBus.GetEventStream<GimmickActivationFailedEvent>()
+                .Subscribe(e => GD.Print($"[Dungeon] GimmickActivationFailed: Room={e.RoomPosition} Gimmick={e.GimmickPosition} Type={e.GimmickType}")));
+        }
+
+        /// <summary>
+        /// ノード破棄時にイベント購読とViewModelを解放する
+        /// </summary>
+        public override void _ExitTree()
+        {
+            foreach (var subscription in _debugLogSubscriptions)
+            {
+                subscription.Dispose();
+            }
+            _debugLogSubscriptions.Clear();
+
+            _tileMapManager.Free();
+            _viewModel.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Issue #96のスコープのうち、計画書 `Docs/06_DevelopmentPlan/11_19_week3_dungeon_integration_test_plan.md` のDay1-3を実装
- Phase A（Day1-2）: `Scenes/Dungeon/DungeonDebug.tscn`・`Scripts/Systems/Dungeon/Views/DungeonView.cs`を追加し、`DungeonViewModel`によるレベル生成・タイルマップ反映・イベントログ出力までを統合
- Phase B（Day3）: 部屋遷移（隣接部屋への遷移ボタン）・ギミック発動（隠し通路/鍵扉、鍵所持は簡易的に常にtrue扱い）・経路表示（`FindPath`結果を`Line2D`で描画）の最低限のデバッグUIを`DungeonView`に追加。`RoomEnteredEvent`/`HiddenPassageRevealedEvent`/`LockedDoorUnlockedEvent`/`GimmickActivationFailedEvent`購読によるUI更新も実装
- `RoomTileGenerator.GetDoorTileType`を公開化し、ギミック発動後の扉タイル再描画に対応
- `Docs/06_DevelopmentPlan/11_19_week3_dungeon_integration_test_plan.md`を実装状況に合わせて更新（Day1-3完了、Day4-7は未着手）

## Test plan
- [x] `dotnet build` — 0 Warning(s), 0 Error(s)
- [x] `dotnet test Tests/Core/CoreTests.csproj` — 201件全pass（うちダンジョン関連113件）
- [ ] Day4-7（単体テスト拡充・統合テスト自動化/CI・パフォーマンス最適化・ドキュメント整備）は未着手
- [ ] 実際の`.tres`タイルセット資産は未作成（プレースホルダーのアトラス座標マッピングのみ）

Refs #96

AX-Tag: ai-work

🤖 Generated with [Claude Code](https://claude.com/claude-code)